### PR TITLE
Fix crash when switching away from a dashboard with a choropleth chart [FE-5321]

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -42182,9 +42182,11 @@ function geoChoroplethChart(parent, useMap, chartGroup, mapbox) {
 
   _chart.destroyChart = function () {
     this.map().remove();
-    if (this.legend()) {
-      this.legend().removeLegend();
-    }
+  };
+
+  _chart.getClosestResult = function () {
+    // don't use logic in mouseup event in map-mixin.js
+    return;
   };
 
   _chart._doRender = function (d) {

--- a/src/charts/geo-choropleth-chart.js
+++ b/src/charts/geo-choropleth-chart.js
@@ -83,9 +83,6 @@ export default function geoChoroplethChart(parent, useMap, chartGroup, mapbox) {
 
   _chart.destroyChart = function() {
     this.map().remove()
-    if (this.legend()) {
-      this.legend().removeLegend()
-    }
   }
 
   _chart.getClosestResult = function() { // don't use logic in mouseup event in map-mixin.js


### PR DESCRIPTION
There's a bug in Immerse where it would crash if you clicked on the "Dashboards" link in the navbar while viewing a dashboard with a choropleth chart. The source of this appears to be mapd-charting sending a "remove legend" event in its `destroyChart()` function. Immerse will remove the chart from its state, then see the event and try to remove the legend from the already removed chart, leading to an error.

This PR makes it so the choropleth chart will not try to remove its legend when destroyed. This behavior is in line with the way other charts behave.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Fixes FE-5321

## :smoking: Smoke Test
- [x] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
