### PR TITLE
Change dependency URLs from old `mapd` org to new `omnisci` org [FE-5366]

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Visit our [examples page](https://mapd.github.io/mapd-charting/example/) for ide
 
 ```bash
 yarn install #downloads all dependencies and devDependencies
-yarn install mapbox-gl@https://github.com/mapd/mapbox-gl-js/tarball/9c04de6949fe498c8c79f5c0627dfd6d6321f307 #downloads mapbox peer dependency
 ```
 
 ##### Step 2: Run Start Script

--- a/package.json
+++ b/package.json
@@ -52,15 +52,15 @@
     "test:unit": "find ./src -name '*.spec.js' | BABEL_ENV=test NODE_PATH=./src xargs nyc mocha --opts ./test/mocha.unit.opts"
   },
   "dependencies": {
-    "@mapd/mapd-draw": "git://github.com/mapd/mapd-draw.git",
+    "@mapd/mapd-draw": "git://github.com/omnisci/mapd-draw.git",
     "@turf/bbox": "^6.0.1",
     "@turf/bbox-clip": "^6.0.3",
     "d3": "^3.5.17",
     "earcut": "^2.1.1",
     "fast-deep-equal": "^2.0.1",
     "http-server": "^0.11.1",
-    "legendables": "git://github.com/mapd/legendables.git#9fd4f0a",
-    "mapbox-gl": "https://github.com/mapd/mapbox-gl-js/tarball/9c04de6949fe498c8c79f5c0627dfd6d6321f307",
+    "legendables": "git://github.com/omnisci/legendables.git#9fd4f0a",
+    "mapbox-gl": "https://github.com/omnisci/mapbox-gl-js/tarball/9c04de6949fe498c8c79f5c0627dfd6d6321f307",
     "mapd-data-layer-2": "0.0.6",
     "moment": "2.13.0",
     "ramda": "0.21.0",
@@ -68,8 +68,8 @@
     "wellknown": "^0.5.0"
   },
   "devDependencies": {
-    "@mapd/connector": "git://github.com/mapd/mapd-connector.git#07a6968",
-    "@mapd/crossfilter": "git://github.com/mapd/mapd-crossfilter.git#fd08fe1",
+    "@mapd/connector": "git://github.com/omnisci/mapd-connector.git#07a6968",
+    "@mapd/crossfilter": "git://github.com/omnisci/mapd-crossfilter.git#fd08fe1",
     "atob": "^2.0.3",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,21 +2,21 @@
 # yarn lockfile v1
 
 
-"@mapd/connector@git://github.com/mapd/mapd-connector.git#07a6968":
+"@mapd/connector@git://github.com/omnisci/mapd-connector.git#07a6968":
   version "1.0.0"
-  resolved "git://github.com/mapd/mapd-connector.git#07a6968fe57537867f31ba6f3772140750956c04"
+  resolved "git://github.com/omnisci/mapd-connector.git#07a6968fe57537867f31ba6f3772140750956c04"
   dependencies:
     codecov "^2.2.0"
     script-loader "^0.7.0"
     thrift "^0.10.0"
 
-"@mapd/crossfilter@git://github.com/mapd/mapd-crossfilter.git#fd08fe1":
+"@mapd/crossfilter@git://github.com/omnisci/mapd-crossfilter.git#fd08fe1":
   version "1.0.0"
-  resolved "git://github.com/mapd/mapd-crossfilter.git#fd08fe1f23bdc8624e47955713b0b19b27605083"
+  resolved "git://github.com/omnisci/mapd-crossfilter.git#fd08fe1f23bdc8624e47955713b0b19b27605083"
 
-"@mapd/mapd-draw@git://github.com/mapd/mapd-draw.git":
+"@mapd/mapd-draw@git://github.com/omnisci/mapd-draw.git":
   version "1.1.0"
-  resolved "git://github.com/mapd/mapd-draw.git#a71db40f4708f7ebd1a74910a90fa96a85267e8b"
+  resolved "git://github.com/omnisci/mapd-draw.git#a71db40f4708f7ebd1a74910a90fa96a85267e8b"
   dependencies:
     css-element-queries "^0.4.0"
     gl-matrix "^2.3.2"
@@ -4752,9 +4752,9 @@ left-pad@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
 
-"legendables@git://github.com/mapd/legendables.git#9fd4f0a":
+"legendables@git://github.com/omnisci/legendables.git#9fd4f0a":
   version "1.0.0-rc.6"
-  resolved "git://github.com/mapd/legendables.git#9fd4f0a23613d52f5e45a5942bdec835bf30d5eb"
+  resolved "git://github.com/omnisci/legendables.git#9fd4f0a23613d52f5e45a5942bdec835bf30d5eb"
   dependencies:
     d3-dispatch "^1.0.3"
     d3-format "^1.2.0"
@@ -5048,9 +5048,9 @@ mapbox-gl-supported@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mapbox-gl-supported/-/mapbox-gl-supported-1.2.0.tgz#cbd34df894206cadda9a33c8d9a4609f26bb1989"
 
-"mapbox-gl@https://github.com/mapd/mapbox-gl-js/tarball/9c04de6949fe498c8c79f5c0627dfd6d6321f307":
+"mapbox-gl@https://github.com/omnisci/mapbox-gl-js/tarball/9c04de6949fe498c8c79f5c0627dfd6d6321f307":
   version "0.28.0"
-  resolved "https://github.com/mapd/mapbox-gl-js/tarball/9c04de6949fe498c8c79f5c0627dfd6d6321f307#998b5cf85ee5a4f62326ef7fcdb7258c8dc1c6e3"
+  resolved "https://github.com/omnisci/mapbox-gl-js/tarball/9c04de6949fe498c8c79f5c0627dfd6d6321f307#bdfa7835e9fafa1a795db6ac5aa568957af6d434"
   dependencies:
     bubleify "^0.5.1"
     csscolorparser "^1.0.2"


### PR DESCRIPTION
MapD is now OmniSci, and our GitHub org has changed names from `mapd` to `omnisci`. This PR changes the URLs for some dependencies in `package.json` that pointed at the old org, to point to the new one.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Fixes FE-5366

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
