### PR TITLE
Make geo column selection work for both tables

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -45930,11 +45930,6 @@ function geoChoroplethChart(parent, useMap, chartGroup, mapbox) {
     return;
   };
 
-  _chart.getClosestResult = function () {
-    // don't use logic in mouseup event in map-mixin.js
-    return;
-  };
-
   _chart._doRender = function (d) {
     _chart.resetSvg(); // will use map mixin reset svg if we inherit map mixin
     for (var layerIndex = 0; layerIndex < _geoJsons.length; ++layerIndex) {
@@ -72643,7 +72638,8 @@ function getTransforms(table, filter, globalFilter, state, lastFilteredSize) {
   var _state$encoding = state.encoding,
       size = _state$encoding.size,
       color = _state$encoding.color,
-      geocol = _state$encoding.geocol;
+      geocol = _state$encoding.geocol,
+      geoTable = _state$encoding.geoTable;
 
   var rowIdTable = doJoin() ? state.data[1].table : state.data[0].table;
 
@@ -72713,7 +72709,7 @@ function getTransforms(table, filter, globalFilter, state, lastFilteredSize) {
     });
     transforms.push({
       type: "project",
-      expr: "SAMPLE(" + table + "." + geocol + ")",
+      expr: "SAMPLE(" + geoTable + "." + geocol + ")",
       as: geocol
     });
   } else {
@@ -72724,7 +72720,7 @@ function getTransforms(table, filter, globalFilter, state, lastFilteredSize) {
     });
     transforms.push({
       type: "project",
-      expr: table + "." + geocol
+      expr: geoTable + "." + geocol
     });
   }
 

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -15419,7 +15419,8 @@ function mapMixin(_chart, chartDivId, _mapboxgl) {
             xdim.filter([_chart._minCoord[0], _chart._maxCoord[0]]);
             ydim.filter([_chart._minCoord[1], _chart._maxCoord[1]]);
           }
-        } else if (typeof layer.viewBoxDim === "function") {
+        } else if (typeof layer.viewBoxDim === "function" && layer.getState().data.length < 2) {
+          debugger;
           var viewBoxDim = layer.viewBoxDim();
           if (viewBoxDim !== null) {
             redrawall = true;
@@ -15441,7 +15442,8 @@ function mapMixin(_chart, chartDivId, _mapboxgl) {
         (0, _coreAsync.resetRedrawStack)();
         console.log("on move event redrawall error:", error);
       });
-    } else if (_viewBoxDim !== null) {
+    } else if (_viewBoxDim !== null && layer.getState().data.length < 2) {
+      debugger;
       _viewBoxDim.filterST_Intersects([[_chart._minCoord[0], _chart._minCoord[1]], [_chart._maxCoord[0], _chart._minCoord[1]], [_chart._maxCoord[0], _chart._maxCoord[1]], [_chart._minCoord[0], _chart._maxCoord[1]]]);
       (0, _coreAsync.redrawAllAsync)(_chart.chartGroup()).catch(function (error) {
         (0, _coreAsync.resetRedrawStack)();
@@ -72642,7 +72644,7 @@ function getTransforms(table, filter, globalFilter, state, lastFilteredSize) {
       geoTable = _state$encoding.geoTable;
 
   var rowIdTable = doJoin() ? state.data[1].table : state.data[0].table;
-
+  debugger;
   var fields = [];
   var alias = [];
   var ops = [];
@@ -72725,12 +72727,17 @@ function getTransforms(table, filter, globalFilter, state, lastFilteredSize) {
   }
 
   if (typeof transform.limit === "number") {
-    if (transform.sample) {
+    if (transform.sample && !doJoin()) {
       transforms.push({
         type: "sample",
         method: "multiplicative",
         size: lastFilteredSize || transform.tableSize,
         limit: transform.limit
+      });
+    } else {
+      transforms.push({
+        type: "limit",
+        row: transform.limit
       });
     }
   }
@@ -72937,7 +72944,7 @@ function rasterLayerLineMixin(_layer) {
       marks[0].properties.x.scale = "x";
       marks[0].properties.y.scale = "y";
     }
-
+    debugger;
     return {
       data: data,
       scales: scales,

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -15420,7 +15420,7 @@ function mapMixin(_chart, chartDivId, _mapboxgl) {
             ydim.filter([_chart._minCoord[1], _chart._maxCoord[1]]);
           }
         } else if (typeof layer.viewBoxDim === "function" && layer.getState().data.length < 2) {
-          debugger;
+          // spatial filter on only single data source
           var viewBoxDim = layer.viewBoxDim();
           if (viewBoxDim !== null) {
             redrawall = true;
@@ -15443,7 +15443,7 @@ function mapMixin(_chart, chartDivId, _mapboxgl) {
         console.log("on move event redrawall error:", error);
       });
     } else if (_viewBoxDim !== null && layer.getState().data.length < 2) {
-      debugger;
+      // spatial filter on only single data source
       _viewBoxDim.filterST_Intersects([[_chart._minCoord[0], _chart._minCoord[1]], [_chart._maxCoord[0], _chart._minCoord[1]], [_chart._maxCoord[0], _chart._maxCoord[1]], [_chart._minCoord[0], _chart._maxCoord[1]]]);
       (0, _coreAsync.redrawAllAsync)(_chart.chartGroup()).catch(function (error) {
         (0, _coreAsync.resetRedrawStack)();
@@ -72644,7 +72644,7 @@ function getTransforms(table, filter, globalFilter, state, lastFilteredSize) {
       geoTable = _state$encoding.geoTable;
 
   var rowIdTable = doJoin() ? state.data[1].table : state.data[0].table;
-  debugger;
+
   var fields = [];
   var alias = [];
   var ops = [];
@@ -72728,6 +72728,7 @@ function getTransforms(table, filter, globalFilter, state, lastFilteredSize) {
 
   if (typeof transform.limit === "number") {
     if (transform.sample && !doJoin()) {
+      // use Knuth's hash sampling on single data source chart
       transforms.push({
         type: "sample",
         method: "multiplicative",
@@ -72735,6 +72736,7 @@ function getTransforms(table, filter, globalFilter, state, lastFilteredSize) {
         limit: transform.limit
       });
     } else {
+      // when geo join is applied, we won't use Knuth's sampling but use LIMIT
       transforms.push({
         type: "limit",
         row: transform.limit
@@ -72944,7 +72946,7 @@ function rasterLayerLineMixin(_layer) {
       marks[0].properties.x.scale = "x";
       marks[0].properties.y.scale = "y";
     }
-    debugger;
+
     return {
       data: data,
       scales: scales,

--- a/src/mixins/map-mixin.js
+++ b/src/mixins/map-mixin.js
@@ -342,7 +342,7 @@ export default function mapMixin(
             ydim.filter([_chart._minCoord[1], _chart._maxCoord[1]])
           }
         }
-        else if(typeof layer.viewBoxDim === "function") {
+        else if(typeof layer.viewBoxDim === "function" && layer.getState().data.length < 2) { // spatial filter on only single data source
           const viewBoxDim = layer.viewBoxDim()
           if(viewBoxDim !== null) {
             redrawall = true
@@ -367,7 +367,7 @@ export default function mapMixin(
         resetRedrawStack()
         console.log("on move event redrawall error:", error)
       })
-    } else if(_viewBoxDim !== null) {
+    } else if(_viewBoxDim !== null && layer.getState().data.length < 2) { // spatial filter on only single data source
       _viewBoxDim.filterST_Intersects([[_chart._minCoord[0], _chart._minCoord[1]],
                             [_chart._maxCoord[0], _chart._minCoord[1]],
                           [_chart._maxCoord[0], _chart._maxCoord[1]],

--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -175,12 +175,17 @@ function getTransforms(
   }
 
   if (typeof transform.limit === "number") {
-    if (transform.sample) {
+    if (transform.sample && !doJoin()) { // use Knuth's hash sampling on single data source chart
       transforms.push({
         type: "sample",
         method: "multiplicative",
         size: lastFilteredSize || transform.tableSize,
         limit: transform.limit
+      })
+    } else { // when geo join is applied, we won't use Knuth's sampling but use LIMIT
+      transforms.push({
+        type: "limit",
+        row: transform.limit
       })
     }
   }

--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -78,7 +78,7 @@ function getTransforms(
 ) {
   const transforms = []
   const { transform } = state
-  const { size, color, geocol } = state.encoding
+  const { size, color, geocol, geoTable } = state.encoding
   const rowIdTable = doJoin() ? state.data[1].table : state.data[0].table
 
   const fields = []
@@ -159,7 +159,7 @@ function getTransforms(
     })
     transforms.push({
       type: "project",
-      expr: `SAMPLE(${table}.${geocol})`,
+      expr: `SAMPLE(${geoTable}.${geocol})`,
       as: geocol
     })
   } else {
@@ -170,7 +170,7 @@ function getTransforms(
     })
     transforms.push({
       type: "project",
-      expr: `${table}.${geocol}`
+      expr: `${geoTable}.${geocol}`
     })
   }
 


### PR DESCRIPTION
# Merge Checklist
## Description: 
Geo measure dropdown could have more than one geo column selections when the chart is geo joined with two datasets that both have geo column. For example, fact table has `omnisci_geo` and the geo table has `mapd_geo` column. The issue addressed here is support selecting either geo measure column from dropdown.
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes https://mapdgpu.atlassian.net/browse/FE-5423
## Related with: https://github.com/omnisci/mapd-immerse/pull/5001


## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
