### PR TITLE
[FE-7314], [FE-7313], LINEMAP: run groupby on dimension 

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -69019,7 +69019,7 @@ function getTransforms(table, filter, globalFilter, state, lastFilteredSize) {
       expr: state.data[0].table + "." + g,
       as: "key" + i
     };
-  }) : {};
+  }) : [];
 
   var groupby = doJoin() ? [{
     type: "project",

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -69013,8 +69013,22 @@ function getTransforms(table, filter, globalFilter, state, lastFilteredSize) {
     return state.data.length > 1;
   }
 
+  var groupbyDim = state.transform.groupby ? state.transform.groupby.map(function (g, i) {
+    return {
+      type: "project",
+      expr: state.data[0].table + "." + g,
+      as: "key" + i
+    };
+  }) : {};
+
+  var groupby = doJoin() ? [{
+    type: "project",
+    expr: state.data[0].table + "." + state.data[0].attr,
+    as: "key0"
+  }] : groupbyDim;
+
   if ((typeof size === "undefined" ? "undefined" : _typeof(size)) === "object" && size.type === "quantitative") {
-    if (doJoin()) {
+    if (groupby.length > 0) {
       fields.push(state.data[0].table + "." + size.field);
       alias.push("strokeWidth");
       ops.push(size.aggregate);
@@ -69028,7 +69042,7 @@ function getTransforms(table, filter, globalFilter, state, lastFilteredSize) {
   }
 
   if ((typeof color === "undefined" ? "undefined" : _typeof(color)) === "object" && (color.type === "quantitative" || color.type === "ordinal")) {
-    if (doJoin()) {
+    if (groupby.length > 0) {
       fields.push(colorProjection);
       alias.push("strokeColor");
       ops.push(null);
@@ -69048,13 +69062,7 @@ function getTransforms(table, filter, globalFilter, state, lastFilteredSize) {
     });
   }
 
-  var groupby = doJoin() ? {
-    type: "project",
-    expr: state.data[0].table + "." + state.data[0].attr,
-    as: "key0"
-  } : {};
-
-  if (doJoin()) {
+  if (groupby.length > 0) {
     transforms.push({
       type: "aggregate",
       fields: fields,

--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -98,7 +98,7 @@ function getTransforms(
     type: "project",
     expr: `${state.data[0].table}.${g}`,
     as: `key${i}`
-  })) : {}
+  })) : []
 
   const groupby = doJoin()
     ? [{


### PR DESCRIPTION
# Merge Checklist
## Description
Support groupby on dimension only without geo join.
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes https://jira.omnisci.com/browse/FE-7314 AND https://jira.omnisci.com/browse/FE-7313

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
