### PR TITLE
[FE-7636] Add a null check to `formatNumber()`, recompile source

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -7154,7 +7154,16 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var NUMBER_LENGTH = 4;
 
-var numFormat = _d2.default.format(".2s");
+var numFormat = function numFormat(d) {
+  if (d < 1000) {
+    return _d2.default.format(",.2f")(d);
+  } else if (d < 1000000) {
+    return _d2.default.format(",.2s")(d);
+  } else {
+    return _d2.default.format(",.0f")(Math.round(d / 1000000)) + "B";
+  }
+};
+
 var commafy = _d2.default.format(",");
 
 var nullLabelHtml = exports.nullLabelHtml = '<tspan class="null-value"> NULL </tspan>';
@@ -7181,9 +7190,9 @@ var normalizeArrayByValue = exports.normalizeArrayByValue = function normalizeAr
   }) : collection;
 };
 
-function formatDataValue(data, numAbbr) {
+function formatDataValue(data) {
   if (typeof data === "number") {
-    return formatNumber(data, numAbbr);
+    return formatNumber(data);
   } else if (Array.isArray(data)) {
     return formatArrayValue(data);
   } else if (data instanceof Date) {
@@ -7204,11 +7213,14 @@ function maybeFormatInfinity(data) {
   });
 }
 
-function formatNumber(d, abbr) {
+function formatNumber(d) {
+  if (d === null || d === undefined) {
+    return "NULL";
+  }
   var isLong = String(d).length > NUMBER_LENGTH;
   var formattedHasAlpha = numFormat(d).match(/[a-z]/i);
   var isLargeNumber = isLong && formattedHasAlpha;
-  return isLargeNumber && abbr ? numFormat(d) : commafy(parseFloat(d.toFixed(2)));
+  return isLargeNumber ? numFormat(d) : commafy(parseFloat(d.toFixed(2)));
 }
 
 function formatArrayValue(data) {
@@ -64962,21 +64974,15 @@ var formatNumber = function (d) {
 };
 function rangeStep(domain, index, bins) {
     if (bins === void 0) { bins = 9; }
-    if (Array.isArray(domain)) {
-        debugger;
-        if (index === 0) {
-            return domain[0];
-        }
-        else if (index + 1 === bins) {
-            return domain[1];
-        }
-        else {
-            var increment = (domain[1] - domain[0]) / bins;
-            return domain[0] + increment * index;
-        }
+    if (index === 0) {
+        return domain[0];
+    }
+    else if (index + 1 === bins) {
+        return domain[1];
     }
     else {
-        return 0;
+        var increment = (domain[1] - domain[0]) / bins;
+        return domain[0] + increment * index;
     }
 }
 function validateNumericalInput(previousValue, nextValue) {
@@ -65057,13 +65063,12 @@ function renderGradientLegend(state, dispatch) {
             ? h_1.default("div.range", state.range.map(function (color, index) {
                 var isMinMax = index === 0 || index === state.range.length - 1;
                 var step = formatNumber(rangeStep(state.domain, index, state.range.length));
-                var domain = (state.domain && Array.isArray(state.domain)) ? state.domain : [0, 0];
-                var min = domain[0], max = domain[1];
+                var _a = state.domain, min = _a[0], max = _a[1];
                 return h_1.default("div.block", [
                     h_1.default("div.color", { style: { background: color } }),
-                    h_1.default("div.text." + (isMinMax ? "extent" : "step"), [h_1.default("span", "" + (domain.length > 2 ? domain[index] : step))].concat(isMinMax
+                    h_1.default("div.text." + (isMinMax ? "extent" : "step"), [h_1.default("span", "" + (state.domain.length > 2 ? state.domain[index] : step))].concat(isMinMax
                         ? [
-                            renderInput(state, { value: domain.length === 2 ? domain[index === 0 ? 0 : 1] : domain[index], index: index }, dispatch)
+                            renderInput(state, { value: state.domain.length === 2 ? state.domain[index === 0 ? 0 : 1] : state.domain[index], index: index }, dispatch)
                         ]
                         : []))
                 ]);
@@ -65087,7 +65092,7 @@ function renderNominalLegend(state, dispatch) {
                     h_1.default("div.color", {
                         style: { background: state.range[index] }
                     }),
-                    h_1.default("div.text", "" + value)
+                    h_1.default("div.text", value)
                 ]);
             }))
             : h_1.default("div")

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -7214,7 +7214,7 @@ function maybeFormatInfinity(data) {
 }
 
 function formatNumber(d) {
-  if (d === null || d === undefined) {
+  if (typeof d !== "number") {
     return "NULL";
   }
   var isLong = String(d).length > NUMBER_LENGTH;

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -7215,7 +7215,7 @@ function maybeFormatInfinity(data) {
 
 function formatNumber(d) {
   if (typeof d !== "number") {
-    return "NULL";
+    return d;
   }
   var isLong = String(d).length > NUMBER_LENGTH;
   var formattedHasAlpha = numFormat(d).match(/[a-z]/i);

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "earcut": "^2.1.1",
     "fast-deep-equal": "^2.0.1",
     "http-server": "^0.11.1",
-    "legendables": "git://github.com/omnisci/legendables.git#977b1f1",
+    "legendables": "git://github.com/omnisci/legendables.git#36cd992",
     "mapbox-gl": "https://github.com/omnisci/mapbox-gl-js/tarball/9c04de6949fe498c8c79f5c0627dfd6d6321f307",
     "mapd-data-layer-2": "0.0.6",
     "moment": "2.13.0",

--- a/src/utils/formatting-helpers.js
+++ b/src/utils/formatting-helpers.js
@@ -58,7 +58,7 @@ export function maybeFormatInfinity(data) {
 
 export function formatNumber(d) {
   if (typeof d !== "number") {
-    return "NULL"
+    return d
   }
   const isLong = String(d).length > NUMBER_LENGTH
   const formattedHasAlpha = numFormat(d).match(/[a-z]/i)

--- a/src/utils/formatting-helpers.js
+++ b/src/utils/formatting-helpers.js
@@ -57,12 +57,13 @@ export function maybeFormatInfinity(data) {
 }
 
 export function formatNumber(d) {
+  if (d === null || d === undefined) {
+    return "NULL"
+  }
   const isLong = String(d).length > NUMBER_LENGTH
   const formattedHasAlpha = numFormat(d).match(/[a-z]/i)
   const isLargeNumber = isLong && formattedHasAlpha
-  return isLargeNumber
-    ? numFormat(d)
-    : commafy(parseFloat(d.toFixed(2)))
+  return isLargeNumber ? numFormat(d) : commafy(parseFloat(d.toFixed(2)))
 }
 
 export function formatArrayValue(data) {
@@ -142,7 +143,7 @@ export function formatCache(_axis) {
   const axis = _axis
   let cachedTickFormat = false
 
-  function setTickFormat (tickFormat, fromCache) {
+  function setTickFormat(tickFormat, fromCache) {
     if (tickFormat === false) {
       return null
     }
@@ -150,15 +151,15 @@ export function formatCache(_axis) {
     if (!fromCache && cachedTickFormat === false) {
       cachedTickFormat = axis.tickFormat()
     }
- 
+
     axis.tickFormat(tickFormat)
- 
+
     if (fromCache) {
       cachedTickFormat = false
     }
   }
 
-  function setTickFormatFromCache () {
+  function setTickFormatFromCache() {
     const FROM_CACHE = true
     setTickFormat(cachedTickFormat, FROM_CACHE)
   }

--- a/src/utils/formatting-helpers.js
+++ b/src/utils/formatting-helpers.js
@@ -57,7 +57,7 @@ export function maybeFormatInfinity(data) {
 }
 
 export function formatNumber(d) {
-  if (d === null || d === undefined) {
+  if (typeof d !== "number") {
     return "NULL"
   }
   const isLong = String(d).length > NUMBER_LENGTH

--- a/yarn.lock
+++ b/yarn.lock
@@ -5576,9 +5576,9 @@ left-pad@^1.3.0:
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
   integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
-"legendables@git://github.com/omnisci/legendables.git#977b1f1":
+"legendables@git://github.com/omnisci/legendables.git#36cd992":
   version "1.0.0-rc.6"
-  resolved "git://github.com/omnisci/legendables.git#977b1f108b48f09a7667009b86ee0be08cbd28aa"
+  resolved "git://github.com/omnisci/legendables.git#36cd992908323744b2c97e4afcdf8bdae013c4a3"
   dependencies:
     d3-dispatch "^1.0.3"
     d3-format "^1.2.0"


### PR DESCRIPTION
This PR adds a non-number check to `formatNumber()` in `formatting-helpers.js`. In the case of a non-number, it returns the string `"NULL"`.

Further, it appears that the source files were not compiled to reflect the latest `master` changes. This PR updates the compiled files to reflect both `master` and these changes.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Fixes FE-7636
