### PR TITLE
[FE-7636] Update legendables to master commit 5f569b6

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "earcut": "^2.1.1",
     "fast-deep-equal": "^2.0.1",
     "http-server": "^0.11.1",
-    "legendables": "git://github.com/omnisci/legendables.git#36cd992",
+    "legendables": "git://github.com/omnisci/legendables.git#5f569b6",
     "mapbox-gl": "https://github.com/omnisci/mapbox-gl-js/tarball/9c04de6949fe498c8c79f5c0627dfd6d6321f307",
     "mapd-data-layer-2": "0.0.6",
     "moment": "2.13.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5576,9 +5576,9 @@ left-pad@^1.3.0:
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
   integrity sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==
 
-"legendables@git://github.com/omnisci/legendables.git#36cd992":
+"legendables@git://github.com/omnisci/legendables.git#5f569b6":
   version "1.0.0-rc.6"
-  resolved "git://github.com/omnisci/legendables.git#36cd992908323744b2c97e4afcdf8bdae013c4a3"
+  resolved "git://github.com/omnisci/legendables.git#5f569b66c843358837a20ac944ef48f388003128"
   dependencies:
     d3-dispatch "^1.0.3"
     d3-format "^1.2.0"


### PR DESCRIPTION
Follow-up from https://github.com/omnisci/mapd-charting/pull/283 and https://github.com/omnisci/mapd-charting/pull/282, merging in https://github.com/omnisci/legendables/pull/7