### PR TITLE
[FE-7547] Unable to zoom in and out while hovering over active popup

### DIFF
--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -823,7 +823,7 @@ body {
     }
 
     .map-polygon-shape {
-        pointer-events: auto;
+        pointer-events: none;
     }
 
 


### PR DESCRIPTION
prevent blocking a zoom when cursor is hover popup that swallows the events

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
