### PR TITLE
[FE-8329][WIP] Disable render/redraw stack guards

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -4773,14 +4773,17 @@ function refreshDisabled(_) {
   if (!arguments.length) {
     return _refreshDisabled;
   }
+  console.debug(">>> Setting refresh disabled to:", _);
   _refreshDisabled = _;
 }
 
 function disableRefresh() {
+  console.debug(">>> Disabling refresh");
   _refreshDisabled = true;
 }
 
 function enableRefresh() {
+  console.debug(">>> Enabling refresh");
   _refreshDisabled = false;
 }
 
@@ -5677,10 +5680,18 @@ function isEqualToRenderCount(queryCount) {
 
 function redrawAllAsync(group, allCharts) {
   if ((0, _core.refreshDisabled)()) {
+    console.warn("redrawAllAsync rejected call because refresh is disabled", {
+      group: group,
+      allCharts: allCharts
+    });
     return Promise.resolve();
   }
 
   if (!startRenderTime()) {
+    console.warn("redrawAllAsync rejected call because startRenderTime is false", {
+      group: group,
+      allCharts: allCharts
+    });
     return Promise.reject("redrawAllAsync() is called before renderAllAsync(), please call renderAllAsync() first.");
   }
 
@@ -5689,6 +5700,11 @@ function redrawAllAsync(group, allCharts) {
   _redrawIdStack = queryGroupId;
 
   if (!stackEmpty) {
+    debugger;
+    console.warn("redrawAllAsync rejected call because stack is not empty", {
+      group: group,
+      allCharts: allCharts
+    });
     _redrawStackEmpty = false;
     return Promise.resolve();
   }
@@ -5731,6 +5747,10 @@ function redrawAllAsync(group, allCharts) {
 
 function renderAllAsync(group, allCharts) {
   if ((0, _core.refreshDisabled)()) {
+    console.warn("renderAllAsync rejected call because refresh is disabled", {
+      group: group,
+      allCharts: allCharts
+    });
     return Promise.resolve();
   }
 
@@ -5739,7 +5759,14 @@ function renderAllAsync(group, allCharts) {
   _renderIdStack = queryGroupId;
 
   if (!stackEmpty) {
+    console.warn("I hate computers:", allCharts ? _core.chartRegistry.listAll() : _core.chartRegistry.list(group));
+    // debugger
     _renderStackEmpty = false;
+    console.warn("renderAllAsync rejected call because stack is not empty", {
+      group: group,
+      allCharts: allCharts,
+      _renderIdStack: JSON.parse(JSON.stringify(_renderIdStack))
+    });
     return Promise.resolve();
   }
 
@@ -43685,6 +43712,7 @@ function asyncMixin(_chart) {
 
   _chart.renderAsync = function (queryGroupId, queryCount) {
     if ((0, _core.refreshDisabled)()) {
+      console.warn("Rejected parallel renderAsync call:", queryGroupId, queryCount);
       return Promise.resolve();
     }
 
@@ -43717,7 +43745,10 @@ function asyncMixin(_chart) {
   };
 
   _chart.redrawAsync = function (queryGroupId, queryCount) {
+    // console.debug(`Calling redrawAsync:`, { queryGroupId, queryCount })
+    // debugger
     if ((0, _core.refreshDisabled)()) {
+      console.warn("Rejected parallel redrawAsync call:", queryGroupId, queryCount);
       return Promise.resolve();
     }
 

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -5700,13 +5700,13 @@ function redrawAllAsync(group, allCharts) {
   _redrawIdStack = queryGroupId;
 
   if (!stackEmpty) {
-    debugger;
+    // debugger
     console.warn("redrawAllAsync rejected call because stack is not empty", {
       group: group,
       allCharts: allCharts
     });
-    _redrawStackEmpty = false;
-    return Promise.resolve();
+    // _redrawStackEmpty = false
+    // return Promise.resolve()
   }
 
   _startRedrawTime = new Date();
@@ -5760,14 +5760,14 @@ function renderAllAsync(group, allCharts) {
 
   if (!stackEmpty) {
     console.warn("I hate computers:", allCharts ? _core.chartRegistry.listAll() : _core.chartRegistry.list(group));
-    // debugger
-    _renderStackEmpty = false;
     console.warn("renderAllAsync rejected call because stack is not empty", {
       group: group,
       allCharts: allCharts,
       _renderIdStack: JSON.parse(JSON.stringify(_renderIdStack))
     });
-    return Promise.resolve();
+    // debugger
+    // _renderStackEmpty = false
+    // return Promise.resolve()
   }
 
   _startRenderTime = new Date();

--- a/src/core/core-async.js
+++ b/src/core/core-async.js
@@ -94,8 +94,8 @@ export function redrawAllAsync(group, allCharts) {
       group,
       allCharts
     })
-    _redrawStackEmpty = false
-    return Promise.resolve()
+    // _redrawStackEmpty = false
+    // return Promise.resolve()
   }
 
   _startRedrawTime = new Date()
@@ -151,14 +151,14 @@ export function renderAllAsync(group, allCharts) {
       `I hate computers:`,
       allCharts ? chartRegistry.listAll() : chartRegistry.list(group)
     )
-    // debugger
-    _renderStackEmpty = false
     console.warn(`renderAllAsync rejected call because stack is not empty`, {
       group,
       allCharts,
       _renderIdStack: JSON.parse(JSON.stringify(_renderIdStack))
     })
-    return Promise.resolve()
+    // debugger
+    // _renderStackEmpty = false
+    // return Promise.resolve()
   }
 
   _startRenderTime = new Date()

--- a/src/core/core-async.js
+++ b/src/core/core-async.js
@@ -89,7 +89,7 @@ export function redrawAllAsync(group, allCharts) {
   _redrawIdStack = queryGroupId
 
   if (!stackEmpty) {
-    debugger
+    // debugger
     console.warn(`redrawAllAsync rejected call because stack is not empty`, {
       group,
       allCharts

--- a/src/core/core-async.js
+++ b/src/core/core-async.js
@@ -64,10 +64,21 @@ export function isEqualToRenderCount(queryCount) {
 
 export function redrawAllAsync(group, allCharts) {
   if (refreshDisabled()) {
+    console.warn(`redrawAllAsync rejected call because refresh is disabled`, {
+      group,
+      allCharts
+    })
     return Promise.resolve()
   }
 
   if (!startRenderTime()) {
+    console.warn(
+      `redrawAllAsync rejected call because startRenderTime is false`,
+      {
+        group,
+        allCharts
+      }
+    )
     return Promise.reject(
       "redrawAllAsync() is called before renderAllAsync(), please call renderAllAsync() first."
     )
@@ -78,6 +89,11 @@ export function redrawAllAsync(group, allCharts) {
   _redrawIdStack = queryGroupId
 
   if (!stackEmpty) {
+    debugger
+    console.warn(`redrawAllAsync rejected call because stack is not empty`, {
+      group,
+      allCharts
+    })
     _redrawStackEmpty = false
     return Promise.resolve()
   }
@@ -119,6 +135,10 @@ export function redrawAllAsync(group, allCharts) {
 
 export function renderAllAsync(group, allCharts) {
   if (refreshDisabled()) {
+    console.warn(`renderAllAsync rejected call because refresh is disabled`, {
+      group,
+      allCharts
+    })
     return Promise.resolve()
   }
 
@@ -127,7 +147,17 @@ export function renderAllAsync(group, allCharts) {
   _renderIdStack = queryGroupId
 
   if (!stackEmpty) {
+    console.warn(
+      `I hate computers:`,
+      allCharts ? chartRegistry.listAll() : chartRegistry.list(group)
+    )
+    // debugger
     _renderStackEmpty = false
+    console.warn(`renderAllAsync rejected call because stack is not empty`, {
+      group,
+      allCharts,
+      _renderIdStack: JSON.parse(JSON.stringify(_renderIdStack))
+    })
     return Promise.resolve()
   }
 

--- a/src/core/core.js
+++ b/src/core/core.js
@@ -47,14 +47,17 @@ export function refreshDisabled(_) {
   if (!arguments.length) {
     return _refreshDisabled
   }
+  console.debug(">>> Setting refresh disabled to:", _)
   _refreshDisabled = _
 }
 
 export function disableRefresh() {
+  console.debug(">>> Disabling refresh")
   _refreshDisabled = true
 }
 
 export function enableRefresh() {
+  console.debug(">>> Enabling refresh")
   _refreshDisabled = false
 }
 

--- a/src/mixins/async-mixin.js
+++ b/src/mixins/async-mixin.js
@@ -64,6 +64,11 @@ export default function asyncMixin(_chart) {
 
   _chart.renderAsync = function(queryGroupId, queryCount) {
     if (refreshDisabled()) {
+      console.warn(
+        `Rejected parallel renderAsync call:`,
+        queryGroupId,
+        queryCount
+      )
       return Promise.resolve()
     }
 
@@ -96,7 +101,14 @@ export default function asyncMixin(_chart) {
   }
 
   _chart.redrawAsync = function(queryGroupId, queryCount) {
+    // console.debug(`Calling redrawAsync:`, { queryGroupId, queryCount })
+    // debugger
     if (refreshDisabled()) {
+      console.warn(
+        `Rejected parallel redrawAsync call:`,
+        queryGroupId,
+        queryCount
+      )
       return Promise.resolve()
     }
 


### PR DESCRIPTION
In `core-async.js` in mapdc, in `redrawAllAsync()` and `renderAllAsync()`, there are checks for `if (!stackEmpty) {...}` that throw away render/redraw calls in-flight when another render/redraw call is requested. This causes a number of bugs, including FE-7800, FE-7815, and FE-8326, which all revolve around renders not happening correctly.

We should try removing this logic and verify that no bugs are introduced. Specifically, we should verify that the original "infinite render loops" bugs that caused this logic to be added are not still present when this logic is removed.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Fixes FE-8329

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
