### PR TITLE
[FE-8326] [FE-8330] tentative fix to render bug

### DIFF
--- a/src/core/core-async.js
+++ b/src/core/core-async.js
@@ -133,7 +133,7 @@ export function renderAllAsync(group, allCharts) {
 
   _startRenderTime = new Date()
 
-  const charts = allCharts ? chartRegistry.listAll() : chartRegistry.list(group)
+  const charts = chartRegistry.listAll()
 
   const createRenderPromises = () =>
     charts.map(chart => {


### PR DESCRIPTION
This `allCharts` was introduced here https://github.com/omnisci/mapd-charting/pull/113/files 
It seems to fix the bug. The reasoning is that renderAll should always be called on all charts.

My understanding is that `chartRegistry.list(group)` is the old behaviour, it would render all charts that are in the same group, but it’s not used in Immerse (notice the null in the main use in dc-action-creators.js):
```.renderAllAsync(null, true)```

combo is using the `group` argument in line2-dc-adapter
```dc.renderAllAsync(groupName)```

But knowing that the `allCharts` argument was introduced in Oct 2017, it's possible that we just forgot to use that signature when we changed the adapter in commit [18c34d4], copying it from the `redrawAllAsync` signature, replacing 
```
    dc.redrawAllAsync(groupName)
```
by 
```
    if (dc.startRenderTime()) {
      dc.redrawAllAsync(groupName)
    } else {
      dc.renderAllAsync(groupName)
    }

```