### PR TITLE
[FE-7408] fixed undefined return value

### DIFF
--- a/src/utils/utils-vega.js
+++ b/src/utils/utils-vega.js
@@ -160,6 +160,10 @@ export function createVegaAttrMixin(
         } else {
           quantScale.domain(domainVals).range(capAttrObj.range)
           rtnVal = quantScale(input)
+
+          if (typeof rtnVal === "undefined") {
+            rtnVal = layerObj[defaultFunc]()
+          }
         }
       }
     }


### PR DESCRIPTION
If the domain of a quant scale is `[x, x]`, the return value of `scale(x)` will be undefined since both the low-end and high-end range values are equally as valid. Simple fix to return the default value if the result is undefined.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes https://jira.omnisci.com/browse/FE-7408

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.