### PR TITLE
[FE-7857] block/delay repeated render/redraw requests *by group*

### DIFF
--- a/src/core/core-async.js
+++ b/src/core/core-async.js
@@ -4,8 +4,6 @@ let _renderId = 0
 let _redrawId = 0
 let _renderCount = 0
 let _redrawCount = 0
-let _renderIdStack = null
-let _redrawIdStack = null
 let _renderStackEmpty = true
 let _redrawStackEmpty = true
 let _startRenderTime = null
@@ -13,6 +11,81 @@ let _startRedrawTime = null
 
 let _groupAll = {}
 let _lastFilteredSize = {}
+
+export class LockTracker {
+  all = false
+  groups = new Set()
+  pendingAll = false
+  pendingGroups = new Set()
+
+  constructor(renderOrRedrawFunc) {
+    this.renderOrRedrawFunc = renderOrRedrawFunc
+  }
+
+  // Utility function to check if a render/redraw should start for the given
+  // group or "all".
+  shouldStart(group, all) {
+    // 1. If currently rendering/redrawing all, return false.
+    // 2. If we're requesting a render/redraw all and *anything* is currently
+    //    rendering/redrawing, return false.
+    // 3. Otherwise, if the requested group is rendering/redrawing, return
+    //    false.
+    return !this.all && (all ? this.groups.size === 0 : !this.groups.has(group))
+  }
+
+  // Call at the start of the render/redraw function. Returns true if the
+  // render/redraw should happen, otherwise, false.
+  request(group, all) {
+    // If it's safe to start this render/redraw, do it and return true
+    if (this.shouldStart(group, all)) {
+      if (all) {
+        this.all = true
+      } else {
+        this.groups.add(group)
+      }
+      return true
+    }
+
+    // If we already have a pending render/redraw all, do nothing
+    if (!this.pendingAll) {
+      if (all) {
+        // record request to render/redraw everything
+        this.pendingAll = true
+        this.pendingGroups.clear()
+      } else {
+        // record request to render/redraw this group
+        this.pendingGroups.add(group)
+      }
+    }
+
+    // Return false: render/redraw should not happen
+    return false
+  }
+
+  // Call when the render/redraw finishes. Returns a function, which returns a
+  // Promise so it can be chained with the Promise returned by render/redraw.
+  finished(group, all) {
+    const that = this
+    return function() {
+      if (all) {
+        that.all = false
+      } else {
+        that.groups.delete(group)
+      }
+
+      if (that.pendingAll) {
+        that.pendingAll = false
+        return that.renderOrRedrawFunc(null, true)
+      } else if (that.pendingGroups.delete(group)) {
+        return that.renderOrRedrawFunc(group)
+      }
+      return Promise.resolve()
+    }
+  }
+}
+
+const renderAllTracker = new LockTracker(renderAllAsync)
+const redrawAllTracker = new LockTracker(redrawAllAsync)
 
 export function startRenderTime() {
   return _startRenderTime
@@ -24,7 +97,6 @@ export function startRedrawTime() {
 
 export function resetRedrawStack() {
   _redrawCount = 0
-  _redrawIdStack = null
 }
 
 export function redrawStackEmpty(isRedrawStackEmpty) {
@@ -49,13 +121,11 @@ export function isEqualToRedrawCount(queryCount) {
 
 export function incrementRenderStack() {
   const queryGroupId = _renderId++
-  _renderIdStack = queryGroupId
   return queryGroupId
 }
 
 export function resetRenderStack() {
   _renderCount = 0
-  _renderIdStack = null
 }
 
 export function isEqualToRenderCount(queryCount) {
@@ -73,15 +143,12 @@ export function redrawAllAsync(group, allCharts) {
     )
   }
 
-  const queryGroupId = _redrawId++
-  const stackEmpty = _redrawIdStack === null
-  _redrawIdStack = queryGroupId
-
-  if (!stackEmpty) {
+  if (!redrawAllTracker.request(group, allCharts)) {
     _redrawStackEmpty = false
     return Promise.resolve()
   }
 
+  const queryGroupId = _redrawId++
   _startRedrawTime = new Date()
 
   const charts = allCharts ? chartRegistry.listAll() : chartRegistry.list(group)
@@ -103,17 +170,20 @@ export function redrawAllAsync(group, allCharts) {
   if (groupAll()) {
     return getLastFilteredSizeAsync()
       .then(() => Promise.all(createRedrawPromises()))
+      .then(redrawAllTracker.finished(group, allCharts))
       .catch(err => {
         console.log(err)
         resetRedrawStack()
         throw err
       })
   } else {
-    return Promise.all(createRedrawPromises()).catch(err => {
-      console.log(err)
-      resetRedrawStack()
-      throw err
-    })
+    return Promise.all(createRedrawPromises())
+      .then(redrawAllTracker.finished(group, allCharts))
+      .catch(err => {
+        console.log(err)
+        resetRedrawStack()
+        throw err
+      })
   }
 }
 
@@ -122,18 +192,15 @@ export function renderAllAsync(group, allCharts) {
     return Promise.resolve()
   }
 
-  const queryGroupId = _renderId++
-  const stackEmpty = _renderIdStack === null
-  _renderIdStack = queryGroupId
-
-  if (!stackEmpty) {
+  if (!renderAllTracker.request(group, allCharts)) {
     _renderStackEmpty = false
     return Promise.resolve()
   }
 
+  const queryGroupId = _renderId++
   _startRenderTime = new Date()
 
-  const charts = chartRegistry.listAll()
+  const charts = allCharts ? chartRegistry.listAll() : chartRegistry.list(group)
 
   const createRenderPromises = () =>
     charts.map(chart => {
@@ -146,11 +213,13 @@ export function renderAllAsync(group, allCharts) {
   }
 
   if (groupAll()) {
-    return getLastFilteredSizeAsync().then(() =>
-      Promise.all(createRenderPromises())
-    )
+    return getLastFilteredSizeAsync()
+      .then(() => Promise.all(createRenderPromises()))
+      .then(renderAllTracker.finished(group, allCharts))
   } else {
-    return Promise.all(createRenderPromises())
+    return Promise.all(createRenderPromises()).then(
+      renderAllTracker.finished(group, allCharts)
+    )
   }
 }
 

--- a/src/core/core-async.js
+++ b/src/core/core-async.js
@@ -25,11 +25,12 @@ export class LockTracker {
   // Utility function to check if a render/redraw should start for the given
   // group or "all".
   shouldStart(group, all) {
+    // Conditions are checked in this order:
     // 1. If currently rendering/redrawing all, return false.
     // 2. If we're requesting a render/redraw all and *anything* is currently
     //    rendering/redrawing, return false.
-    // 3. Otherwise, if the requested group is rendering/redrawing, return
-    //    false.
+    // 3. If the requested group is rendering/redrawing, return false.
+    // 4. Otherwise, return true.
     return !this.all && (all ? this.groups.size === 0 : !this.groups.has(group))
   }
 

--- a/src/core/core-async.unit.spec.js
+++ b/src/core/core-async.unit.spec.js
@@ -9,6 +9,104 @@ describe("Core Async", () => {
     dc.chartRegistry.clear()
   })
 
+  describe("Tracker", () => {
+    let tracker = null
+
+    beforeEach(() => {
+      tracker = new dc.LockTracker(chai.spy())
+    })
+
+    describe("shouldStart", () => {
+      it("should return true when nothing is tracked", () => {
+        expect(tracker.shouldStart("group")).to.be.true
+        expect(tracker.shouldStart(null, true)).to.be.true
+      })
+
+      it("should return false if a group is already tracked", () => {
+        tracker.request("group")
+        expect(tracker.shouldStart("group")).to.be.false
+        expect(tracker.shouldStart(null, true)).to.be.false
+      })
+
+      it("should return true even if another group is tracked", () => {
+        tracker.request("group1")
+        expect(tracker.shouldStart("group2")).to.be.true
+      })
+
+      it("should return false if 'all' is tracked", () => {
+        tracker.request(null, true)
+        expect(tracker.shouldStart("group")).to.be.false
+        expect(tracker.shouldStart(null, true)).to.be.false
+      })
+    })
+
+    describe("request", () => {
+      it("should return true and track group if nothing is tracked", () => {
+        expect(tracker.request("group")).to.be.true
+        expect(tracker.groups.has("group")).to.be.true
+      })
+
+      it("should return true and track all if nothing is tracked", () => {
+        expect(tracker.request(null, true)).to.be.true
+        expect(tracker.all).to.be.true
+      })
+
+      it("should return true and track a new group, even if another group is tracked", () => {
+        tracker.request("group1")
+        expect(tracker.request("group2")).to.be.true
+        expect(tracker.groups.has("group2")).to.be.true
+      })
+
+      it("should return false and mark pending if a group is already tracked", () => {
+        tracker.request("group")
+        expect(tracker.request("group")).to.be.false
+        expect(tracker.pendingGroups.has("group")).to.be.true
+      })
+
+      it("should return false and mark pending if tracking all", () => {
+        tracker.request(null, true)
+        expect(tracker.request("group")).to.be.false
+        expect(tracker.pendingGroups.has("group")).to.be.true
+      })
+
+      it("should return false, mark pending all, and clear pending groups if requesting all while tracking something", () => {
+        tracker.request("group")
+        tracker.request("group")
+        expect(tracker.request(null, true)).to.be.false
+        expect(tracker.pendingAll).to.be.true
+        expect(tracker.pendingGroups).to.be.empty
+      })
+    })
+
+    describe("finished", () => {
+      it("should clear the tracked group", () => {
+        tracker.request("group")
+        tracker.finished("group")()
+        expect(tracker.groups.has("group")).to.be.false
+      })
+
+      it("should clear the all flag", () => {
+        tracker.request(null, true)
+        tracker.finished(null, true)()
+        expect(tracker.all).to.be.false
+      })
+
+      it("should chain to the pending group", () => {
+        tracker.request("group")
+        tracker.request("group")
+        tracker.finished("group")()
+        expect(tracker.renderOrRedrawFunc).to.have.been.called.once.with("group")
+      })
+
+      it("should chain to all", () => {
+        tracker.request("group")
+        tracker.request(null, true)
+        tracker.finished("group")()
+        expect(tracker.renderOrRedrawFunc).to.have.been.called.once.with(null, true)
+      })
+    })
+  })
+
   describe("redrawAllAsync", () => {
     function mockDataAsync(group, callback) {
       callback(null, [])


### PR DESCRIPTION
Currently, `renderAllAsync` and `redrawAllAsync` throw away any requests to render/redraw if it's currently rendering/redrawing something. This PR changes the logic to keep track of requests per group:
* If the group is *not* rendering/redrawing, then it starts, even if other group(s) are rendering/redrawing;
* Otherwise,
  * If a "note" has been made (see next bullet), nothing happens; request is thrown away.
  * If a "note" has not been made, then it is noted that the group has requested another render/redraw. When the original render/redraw has finished, the note is deleted and the group renders/redraws again.

All of this logic assumes the `allCharts` parameter is falsey. If it is truthy, then that usurps all the logic:
* If nothing is rendering/redrawing currently, everything renders/redraws,
* Otherwise, a "note" is made that everything should render/redraw. As long as this note exists, any additional requests to render/redraw (even by group) are thrown away. When the original render/redraw finishes, the note is deleted and everything renders/redraws.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Fixes [FE-7857](https://jira.omnisci.com/browse/FE-7857)
  - Also relates to [FE-8329](https://jira.omnisci.com/browse/FE-8329)

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.