### PR TITLE
[FE-7857] block/delay repeated render/redraw requests *by group*

### DIFF
--- a/src/core/core-async.js
+++ b/src/core/core-async.js
@@ -4,15 +4,153 @@ let _renderId = 0
 let _redrawId = 0
 let _renderCount = 0
 let _redrawCount = 0
-let _renderIdStack = null
-let _redrawIdStack = null
-let _renderStackEmpty = true
-let _redrawStackEmpty = true
 let _startRenderTime = null
 let _startRedrawTime = null
 
 let _groupAll = {}
 let _lastFilteredSize = {}
+
+// NOTE: a "group" of null is valid!
+export class LockTracker {
+  all = null
+  groups = {}
+  pendingAll = null
+  pendingGroups = {}
+
+  // Utility function to check if a render/redraw should start for the given
+  // group or "all".
+  shouldStart(group, all) {
+    // Conditions are checked in this order:
+    // 1. If currently rendering/redrawing all, return false.
+    // 2. If we're requesting a render/redraw all and *anything* is currently
+    //    rendering/redrawing, return false.
+    // 3. If the requested group is rendering/redrawing, return false.
+    // 4. Otherwise, return true.
+    return (
+      !this.all &&
+      (all ? Object.keys(this.groups).length === 0 : !this.groups[group])
+    )
+  }
+
+  // Returns true if nothing is currently rendering. If a "group" is given,
+  // returns true if neither "all" nor the group is rendering.
+  isEmpty(group) {
+    if (typeof group !== "undefined") {
+      return this.shouldStart(group, false)
+    }
+    return this.shouldStart(null, true)
+  }
+
+  start(group, all, runner) {
+    // if we can safely start this group/all, go for it!
+    if (this.shouldStart(group, all)) {
+      return this._run(group, all, runner)
+    }
+
+    // otherwise, if we already have a pending promise, return it
+    if (this.pendingAll) {
+      return this.pendingAll
+    } else if (this.pendingGroups[group]) {
+      return this.pendingGroups[group]
+    }
+
+    // Ok, we can't start running now, and we don't already have a pending
+    // promise. We need to create a new pending promise to run after the
+    // currently running promise is finished. If we got this far, one of the
+    // following states must be true, otherwise shouldStart would have returned
+    // true and we would have started running already:
+    // 1. this.all is not-null, which means we can wait on that promise
+    // 2. "all" is truthy, which means we need to wait on all of the groups
+    //    that are currently running to finish
+    // 3. "all" is not set, so we only need to wait on the group to finish
+    let promise =
+      this.all ||
+      (all
+        ? // Promise.all returns immediately if any of the promises reject - we
+          // want to wait on them all regardless if any reject, so we
+          // explicitly catch and return an empty array so that if the promise
+          // rejects, it'll end up resolving in this context
+          Promise.all(Object.values(this.groups).map(p => p.catch(() => [])))
+        : this.groups[group])
+
+    // Whether or not the running promise is resolved or rejected, we want to
+    // run the next promise. Maybe if the current promise failed, re-running it
+    // will succeed. We use then(nextRunner, nextRunner) in both blocks below
+    // instead of finally() because we need nextRunner to return a new promise.
+    // The return value from finally() is ignored. Not to mention, the
+    // es6/es2015 polyfill doesn't include finally() anyway =)
+    if (all) {
+      const nextRunner = () => {
+        this.pendingAll = null
+        return this._run(group, all, runner)
+      }
+      promise = promise.then(nextRunner, nextRunner)
+      this.pendingAll = promise
+    } else {
+      const nextRunner = () => {
+        delete this.pendingGroups[group]
+
+        if (this.pendingAll) {
+          // Group was queued before "all", so, we just return the pendingAll
+          // promise. When pendingAll is done, this group will technically
+          // have been run along with all the other groups, so there's no
+          // reason to handle the group individually.
+          return this.pendingAll
+        }
+
+        return this._run(group, all, runner)
+      }
+      promise = promise.then(nextRunner, nextRunner)
+      this.pendingGroups[group] = promise
+    }
+    return promise
+  }
+
+  // private method to start a runner and save the promise
+  _run(group, all, runner) {
+    const cleanup = () => {
+      if (all) {
+        this.all = null
+      } else {
+        delete this.groups[group]
+      }
+    }
+
+    // Start the runner - whether it succeeds or not, cleanup.
+    // The es6/es2015 polyfill doesn't include .finally(), so we use .then()
+    // and make sure to pass the resolved/rejected state up the stack. If we
+    // ever upgrade to the es7 polyfill, this can be rewritten as:
+    // runner().finally(clean)
+    let promise = null
+    try {
+      promise = runner()
+    } catch (err) {
+      promise = Promise.reject(err)
+    }
+    promise = promise.then(
+      val => {
+        cleanup()
+        return val
+      },
+      err => {
+        cleanup()
+        throw err
+      }
+    )
+
+    // store a reference to the promise
+    if (all) {
+      this.all = promise
+    } else {
+      this.groups[group] = promise
+    }
+
+    return promise
+  }
+}
+
+const renderAllTracker = new LockTracker()
+const redrawAllTracker = new LockTracker()
 
 export function startRenderTime() {
   return _startRenderTime
@@ -24,23 +162,14 @@ export function startRedrawTime() {
 
 export function resetRedrawStack() {
   _redrawCount = 0
-  _redrawIdStack = null
 }
 
-export function redrawStackEmpty(isRedrawStackEmpty) {
-  if (!arguments.length) {
-    return _redrawStackEmpty
-  }
-  _redrawStackEmpty = isRedrawStackEmpty
-  return _redrawStackEmpty
+export function redrawStackEmpty(group) {
+  return redrawAllTracker.isEmpty(group)
 }
 
-export function renderStackEmpty(isRenderStackEmpty) {
-  if (!arguments.length) {
-    return _renderStackEmpty
-  }
-  _renderStackEmpty = isRenderStackEmpty
-  return _renderStackEmpty
+export function renderStackEmpty(group) {
+  return renderAllTracker.isEmpty(group)
 }
 
 export function isEqualToRedrawCount(queryCount) {
@@ -49,13 +178,11 @@ export function isEqualToRedrawCount(queryCount) {
 
 export function incrementRenderStack() {
   const queryGroupId = _renderId++
-  _renderIdStack = queryGroupId
   return queryGroupId
 }
 
 export function resetRenderStack() {
   _renderCount = 0
-  _renderIdStack = null
 }
 
 export function isEqualToRenderCount(queryCount) {
@@ -63,8 +190,10 @@ export function isEqualToRenderCount(queryCount) {
 }
 
 export function redrawAllAsync(group, allCharts) {
+  const charts = allCharts ? chartRegistry.listAll() : chartRegistry.list(group)
+
   if (refreshDisabled()) {
-    return Promise.resolve()
+    return Promise.resolve(charts)
   }
 
   if (!startRenderTime()) {
@@ -73,85 +202,71 @@ export function redrawAllAsync(group, allCharts) {
     )
   }
 
-  const queryGroupId = _redrawId++
-  const stackEmpty = _redrawIdStack === null
-  _redrawIdStack = queryGroupId
+  return redrawAllTracker.start(group, allCharts, () => {
+    const queryGroupId = _redrawId++
+    _startRedrawTime = new Date()
 
-  if (!stackEmpty) {
-    _redrawStackEmpty = false
-    return Promise.resolve()
-  }
-
-  _startRedrawTime = new Date()
-
-  const charts = allCharts ? chartRegistry.listAll() : chartRegistry.list(group)
-
-  const createRedrawPromises = () =>
-    charts.map(chart => {
-      chart.expireCache()
-      chart._invokeDataFetchListener()
-      return chart.redrawAsync(queryGroupId, charts.length).catch(e => {
-        chart._invokeDataErrorListener()
-        throw e
+    const createRedrawPromises = () =>
+      charts.map(chart => {
+        chart.expireCache()
+        chart._invokeDataFetchListener()
+        return chart.redrawAsync(queryGroupId, charts.length).catch(e => {
+          chart._invokeDataErrorListener()
+          throw e
+        })
       })
-    })
 
-  if (renderlet() !== null) {
-    renderlet(group)
-  }
+    if (renderlet() !== null) {
+      renderlet(group)
+    }
 
-  if (groupAll()) {
-    return getLastFilteredSizeAsync()
-      .then(() => Promise.all(createRedrawPromises()))
-      .catch(err => {
+    if (groupAll()) {
+      return getLastFilteredSizeAsync()
+        .then(() => Promise.all(createRedrawPromises()))
+        .catch(err => {
+          console.log(err)
+          resetRedrawStack()
+          throw err
+        })
+    } else {
+      return Promise.all(createRedrawPromises()).catch(err => {
         console.log(err)
         resetRedrawStack()
         throw err
       })
-  } else {
-    return Promise.all(createRedrawPromises()).catch(err => {
-      console.log(err)
-      resetRedrawStack()
-      throw err
-    })
-  }
+    }
+  })
 }
 
 export function renderAllAsync(group, allCharts) {
+  const charts = allCharts ? chartRegistry.listAll() : chartRegistry.list(group)
+
   if (refreshDisabled()) {
-    return Promise.resolve()
+    return Promise.resolve(charts)
   }
 
-  const queryGroupId = _renderId++
-  const stackEmpty = _renderIdStack === null
-  _renderIdStack = queryGroupId
+  return renderAllTracker.start(group, allCharts, () => {
+    const queryGroupId = _renderId++
+    _startRenderTime = new Date()
 
-  if (!stackEmpty) {
-    _renderStackEmpty = false
-    return Promise.resolve()
-  }
+    const createRenderPromises = () =>
+      charts.map(chart => {
+        chart.expireCache()
+        return chart.renderAsync(queryGroupId, charts.length)
+      })
 
-  _startRenderTime = new Date()
+    if (renderlet() !== null) {
+      renderlet(group)
+    }
 
-  const charts = chartRegistry.listAll()
-
-  const createRenderPromises = () =>
-    charts.map(chart => {
-      chart.expireCache()
-      return chart.renderAsync(queryGroupId, charts.length)
-    })
-
-  if (renderlet() !== null) {
-    renderlet(group)
-  }
-
-  if (groupAll()) {
-    return getLastFilteredSizeAsync().then(() =>
-      Promise.all(createRenderPromises())
-    )
-  } else {
-    return Promise.all(createRenderPromises())
-  }
+    if (groupAll()) {
+      return getLastFilteredSizeAsync().then(() =>
+        Promise.all(createRenderPromises())
+      )
+    } else {
+      return Promise.all(createRenderPromises())
+    }
+  })
 }
 
 export function groupAll(group) {
@@ -228,6 +343,4 @@ export function setLastFilteredSize(crossfilterId, value) {
 export function resetState() {
   _groupAll = {}
   _lastFilteredSize = {}
-  resetRedrawStack()
-  resetRenderStack()
 }

--- a/src/core/core-async.unit.spec.js
+++ b/src/core/core-async.unit.spec.js
@@ -9,6 +9,259 @@ describe("Core Async", () => {
     dc.chartRegistry.clear()
   })
 
+  describe("Tracker", () => {
+    let tracker = null
+
+    function runner() {
+      return Promise.resolve()
+    }
+
+    // This fixes an issue in mocha where async tests will simply error with
+    // "done() called multiple times" if an expectation fails instead of
+    // showing the information about the failed expectation.
+    function asyncTestWrapper(tester) {
+      return (done) => {
+        let hasError = false
+        try {
+          return tester(val => {
+            if (!hasError) {
+              done(val)
+            }
+          })
+        } catch (err) {
+          hasError = true
+          throw err
+        }
+      }
+    }
+
+    beforeEach(() => {
+      tracker = new dc.LockTracker(chai.spy())
+    })
+
+    describe("_run", () => {
+      it("should set and unset the group", asyncTestWrapper((done) => {
+        tracker._run("group", false, runner).then(() => {
+          expect(Object.keys(tracker.groups)).to.be.empty
+          done()
+        })
+        expect(tracker.groups).to.have.keys("group")
+      }))
+
+      it("should set and unset all", asyncTestWrapper((done) => {
+        tracker._run(null, true, runner).then(() => {
+          expect(tracker.all).to.be.null
+          done()
+        })
+        expect(tracker.all).to.not.be.null
+      }))
+
+      it("should set and unset multiple groups", asyncTestWrapper((done) => {
+        let finished = 0
+        const doneAll = () => {
+          if (++finished === 3) {
+            done()
+          }
+        }
+
+        tracker._run("group1", false, runner).then(() => {
+          expect(tracker.groups).to.not.have.keys("group1")
+          doneAll()
+        })
+        tracker._run("group2", false, runner).then(() => {
+          expect(tracker.groups).to.not.have.keys("group2")
+          doneAll()
+        })
+        tracker._run("group3", false, runner).then(() => {
+          expect(tracker.groups).to.not.have.keys("group3")
+          doneAll()
+        })
+        expect(tracker.groups).to.have.keys("group1", "group2", "group3")
+      }))
+    })
+
+    describe("shouldStart", () => {
+      it("should return true when nothing is tracked", () => {
+        expect(tracker.shouldStart("group")).to.be.true
+        expect(tracker.shouldStart(null, true)).to.be.true
+      })
+
+      it("should return false if a group is already tracked", asyncTestWrapper((done) => {
+        tracker._run("group", false, runner).then(done)
+        expect(tracker.shouldStart("group")).to.be.false
+        expect(tracker.shouldStart(null, true)).to.be.false
+      }))
+
+      it("should return true even if another group is tracked", asyncTestWrapper((done) => {
+        tracker._run("group1", false, runner).then(done)
+        expect(tracker.shouldStart("group2")).to.be.true
+      }))
+
+      it("should return false if 'all' is tracked", asyncTestWrapper((done) => {
+        tracker._run(null, true, runner).then(done)
+        expect(tracker.shouldStart("group")).to.be.false
+        expect(tracker.shouldStart(null, true)).to.be.false
+      }))
+    })
+
+    describe("isEmpty", () => {
+      it("should return true when nothing is tracked", () => {
+        expect(tracker.isEmpty()).to.be.true
+        expect(tracker.isEmpty("group")).to.be.true
+      })
+
+      it("should return false if a group is tracked", asyncTestWrapper((done) => {
+        tracker._run("group", false, runner).then(done)
+        expect(tracker.isEmpty()).to.be.false
+        expect(tracker.isEmpty("group")).to.be.false
+        expect(tracker.isEmpty("group2")).to.be.true
+      }))
+
+      it("should return false if all is tracked", asyncTestWrapper((done) => {
+        tracker._run(null, true, runner).then(done)
+        expect(tracker.isEmpty()).to.be.false
+        expect(tracker.isEmpty("group")).to.be.false
+        expect(tracker.isEmpty("group2")).to.be.false
+      }))
+    })
+
+    describe("start", () => {
+      it("should start running when nothing is tracked", asyncTestWrapper((done) => {
+        const spyRunner = chai.spy(runner)
+        tracker.start("group", false, spyRunner).then(() => {
+          expect(spyRunner).to.have.been.called.once
+          expect(tracker.groups).to.not.have.keys("group")
+          done()
+        })
+        expect(tracker.groups).to.have.keys("group")
+      }))
+
+      it("should start running even if a different group is running", asyncTestWrapper((done) => {
+        const spyRunner = chai.spy(runner)
+
+        let finished = 0
+        const doneAll = () => {
+          if (++finished === 2) {
+            expect(spyRunner).to.have.been.called.twice
+            expect(tracker.groups).to.not.have.keys("group1", "group2")
+            done()
+          }
+        }
+
+        tracker.start("group1", false, spyRunner).then(doneAll)
+        tracker.start("group2", false, spyRunner).then(doneAll)
+        expect(tracker.groups).to.have.keys("group1", "group2")
+      }))
+
+      it("should start running a group after all has completed", asyncTestWrapper((done) => {
+        const spyRunner = chai.spy(runner)
+        const runner2 = () => {
+          expect(spyRunner).to.have.been.called.once
+          expect(tracker.all).to.be.null
+          return runner().then(() => {
+            expect(tracker.groups).to.have.keys("group")
+          })
+        }
+
+        tracker.start(null, true, spyRunner)
+        tracker.start("group", false, runner2).then(() => {
+          expect(tracker.groups).to.not.have.keys("group")
+          done()
+        })
+        expect(tracker.all).to.not.be.null
+        expect(tracker.pendingGroups).to.have.keys("group")
+      }))
+
+      it("should start running all after all groups complete", asyncTestWrapper((done) => {
+        const spyRunner = chai.spy(runner)
+        const runner2 = () => {
+          expect(spyRunner).to.have.been.called.twice
+          expect(Object.keys(tracker.groups)).to.be.empty
+          expect(tracker.pendingAll).to.be.null
+          return runner().then(() => {
+            expect(tracker.all).to.not.be.null
+          })
+        }
+
+        tracker.start("group1", false, spyRunner)
+        tracker.start("group2", false, spyRunner)
+        tracker.start(null, true, runner2).then(() => {
+          expect(tracker.all).to.be.null
+          done()
+        })
+        expect(tracker.all).to.be.null
+        expect(tracker.pendingAll).to.not.be.null
+        expect(tracker.groups).to.have.keys("group1", "group2")
+      }))
+
+      it("should start running a group after the previous run completes", asyncTestWrapper((done) => {
+        const spyRunner = chai.spy(runner)
+        const runner2 = () => {
+          expect(spyRunner).to.have.been.called.once
+          expect(tracker.groups).to.not.have.keys("group")
+          expect(tracker.pendingGroups).to.not.have.keys("group")
+          return runner().then(() => {
+            expect(tracker.groups).to.have.keys("group")
+          })
+        }
+
+        tracker.start("group", false, spyRunner)
+        tracker.start("group", false, runner2).then(() => {
+          expect(tracker.groups).to.not.have.keys("group")
+          done()
+        })
+        expect(tracker.groups).to.have.keys("group")
+        expect(tracker.pendingGroups).to.have.keys("group")
+      }))
+
+      it("should only run pending processes once no matter how many times queued", asyncTestWrapper(done => {
+        const spyRunner = chai.spy(runner)
+        const finished = () => {
+          // this should only be called once... if not, we'll get a "done()
+          // called multiple times" error
+          expect(spyRunner).to.be.called.once
+          expect(tracker.groups).to.not.have.keys("group")
+          expect(tracker.pendingGroups).to.not.have.keys("group")
+          done()
+        }
+
+        tracker.start("group", false, runner)
+
+        const promise1 = tracker.start("group", false, spyRunner)
+        const promise2 = tracker.start("group", false, spyRunner)
+        expect(tracker.groups).to.have.keys("group")
+        expect(tracker.pendingGroups).to.have.keys("group")
+        expect(promise1).to.equal(promise2)
+
+        promise2.then(finished)
+      }))
+
+      it("should run a pending process even if the running process fails", asyncTestWrapper(done => {
+        // if this test times out, it's probably because verifyCatch is not
+        // getting run correctly.
+        let finished = 0
+        const spyRunner = chai.spy(() => Promise.reject('error'))
+        const verifyCatch = err => {
+          expect(err).to.eql("error")
+          doneAll()
+        }
+        const doneAll = () => {
+          if (++finished === 2) {
+            expect(spyRunner).to.be.called.once
+            expect(tracker.groups).to.not.have.keys("group")
+            expect(tracker.pendingGroups).to.not.have.keys("group")
+            done()
+          }
+        }
+
+        tracker.start("group", false, spyRunner).catch(verifyCatch)
+        tracker.start("group", false, runner).then(doneAll)
+        expect(tracker.groups).to.have.keys("group")
+        expect(tracker.pendingGroups).to.have.keys("group")
+      }))
+    })
+  })
+
   describe("redrawAllAsync", () => {
     function mockDataAsync(group, callback) {
       callback(null, [])
@@ -47,20 +300,6 @@ describe("Core Async", () => {
           })
           done()
         })
-    })
-
-    it("should immediately resolve and set redraw stack empty to false when invoked when redrawAllAsync is already in flight", done => {
-      dc.chartRegistry.list()[0].redrawAsync = () =>
-        new Promise(resolve => {
-          setTimeout(() => resolve())
-        })
-
-      expect(dc.redrawStackEmpty()).to.equal(true)
-      dc.redrawAllAsync()
-      dc.redrawAllAsync().then(() => {
-        expect(dc.redrawStackEmpty()).to.equal(false)
-        done()
-      })
     })
   })
 

--- a/src/mixins/base-mixin.js
+++ b/src/mixins/base-mixin.js
@@ -874,9 +874,7 @@ export default function baseMixin(_chart) {
         globalTransitionDuration(null)
         resetRenderStack()
 
-        if (!renderStackEmpty()) {
-          renderStackEmpty(true)
-
+        if (renderStackEmpty(null)) {
           return renderAllAsync(null)
             .then(result => {
               callback(null, result)
@@ -961,10 +959,9 @@ export default function baseMixin(_chart) {
         globalTransitionDuration(null) // reset to null if was brush
         resetRedrawStack()
 
-        if (!redrawStackEmpty()) {
-          redrawStackEmpty(true)
-
-          return redrawAllAsync(_chart.chartGroup())
+        const group = _chart.chartGroup()
+        if (redrawStackEmpty(group)) {
+          return redrawAllAsync(group)
             .then(result => {
               callback(null, result)
             })


### PR DESCRIPTION
I reworked a lot of the render/redraw logic in this PR to remove these confusing "stacks". The idea is:

1. If there is a request to render/redraw and nothing is rendering/redrawing, it begins immediately.
2. If "all" charts are already rendering/redrawing, or if the given group is already rendering/redrawing, *and* there is no pending request for all or the group, then the request is marked pending and a promise is returned. Once the original rendering/redrawing has finished, the pending request begins automatically. Once it finishes, the promise will resolve or reject appropriately.
3. If there is already a pending request, the promise for the pending request is returned. In this way, a maximum of one pending request will queue up for the given group (or all), and all callers will be notified when it finishes via the promise.

There's also some logic where a pending "all" request will usurp pending groups; ie, if a pending group is selected to run, but there's a pending "all", it just returns the pending all's promise and exits since the all will take care of this group automatically.

I've also changed the "stack empty" logic: basically, if the given group (or "all") is not rendering or redrawing, the stack is empty. This is simple enough, I think, to prevent the infinite loop this code was originally trying to solve.

This is a big PR, but hopefully it makes more sense than the previous code. I tried to add comments and unit tests to make the code maintainable for future code spelunkers.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes [FE-7857](https://jira.omnisci.com/browse/FE-7857)

## :smoking: Smoke Test
- [x] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
