### PR TITLE
[FE-8644] Heatmap Y and X axis filter for timestamp bug fix

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -66850,7 +66850,8 @@ function heatMapKeyAccessor(_ref) {
   var key0 = _ref.key0;
 
   if (Array.isArray(key0)) {
-    var value = (0, _formattingHelpers.isArrayOfObjects)(key0) ? key0[0].value : key0[0];
+    var key0Val = (0, _formattingHelpers.isArrayOfObjects)(key0) ? key0[0].value : key0[0];
+    var value = key0Val instanceof Date ? (0, _formattingHelpers.formatDataValue)(key0Val) : key0Val;
     this.colsMap.set(value, key0);
     return value;
   } else {
@@ -66862,7 +66863,8 @@ function heatMapValueAccesor(_ref2) {
   var key1 = _ref2.key1;
 
   if (Array.isArray(key1)) {
-    var value = (0, _formattingHelpers.isArrayOfObjects)(key1) ? key1[0].value : key1[0];
+    var key1Val = (0, _formattingHelpers.isArrayOfObjects)(key1) ? key1[0].value : key1[0];
+    var value = key1Val instanceof Date ? (0, _formattingHelpers.formatDataValue)(key1Val) : key1Val;
     this.rowsMap.set(value, key1);
     return value;
   } else {
@@ -67039,10 +67041,11 @@ function heatMap(parent, chartGroup) {
   };
 
   function filterAxis(axis, value) {
+    var axisVal = value instanceof Date ? (0, _formattingHelpers.formatDataValue)(value) : value;
     var cellsOnAxis = _chart.selectAll(".box-group").filter(function (d) {
       return (
         /* OVERRIDE ---------------------------------------------------------------*/
-        (axis === 1 ? _chart.valueAccessor()(d) : _chart.keyAccessor()(d)) === value
+        (axis === 1 ? _chart.valueAccessor()(d) : _chart.keyAccessor()(d)) === axisVal
       );
     }
     /* --------------------------------------------------------------------------*/

--- a/src/charts/heatmap.js
+++ b/src/charts/heatmap.js
@@ -37,7 +37,8 @@ const MIN_AXIS_HEIGHT = 52
 
 export function heatMapKeyAccessor({ key0 }) {
   if (Array.isArray(key0)) {
-    const value = isArrayOfObjects(key0) ? key0[0].value : key0[0]
+    const key0Val = isArrayOfObjects(key0) ? key0[0].value : key0[0]
+    const value = key0Val instanceof Date ? formatDataValue(key0Val) : key0Val
     this.colsMap.set(value, key0)
     return value
   } else {
@@ -47,7 +48,8 @@ export function heatMapKeyAccessor({ key0 }) {
 
 export function heatMapValueAccesor({ key1 }) {
   if (Array.isArray(key1)) {
-    const value = isArrayOfObjects(key1) ? key1[0].value : key1[0]
+    const key1Val = isArrayOfObjects(key1) ? key1[0].value : key1[0]
+    const value = key1Val instanceof Date ? formatDataValue(key1Val) : key1Val
     this.rowsMap.set(value, key1)
     return value
   } else {
@@ -265,11 +267,12 @@ export default function heatMap(parent, chartGroup) {
   }
 
   function filterAxis(axis, value) {
+    const axisVal = value instanceof Date ? formatDataValue(value) : value
     const cellsOnAxis = _chart.selectAll(".box-group").filter(
       d =>
         /* OVERRIDE ---------------------------------------------------------------*/
         (axis === 1 ? _chart.valueAccessor()(d) : _chart.keyAccessor()(d)) ===
-        value
+        axisVal
       /* --------------------------------------------------------------------------*/
     )
 


### PR DESCRIPTION
## Description:
Heatmap axis' filter is not filtering matching timestamp values correctly, so using moment.js formatter helps to filter properly.

## Relates with:
https://github.com/omnisci/mapd-immerse/pull/5532
# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #https://jira.omnisci.com/browse/FE-8644

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
