### PR TITLE
[FE-8750] Anticipate milliseconds when comparing dates in table chart

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -51629,19 +51629,50 @@ function addFilterHandler(filters, filter) {
   return filters;
 }
 
-function hasFilterHandler(filters, filter) {
-  if (typeof filter === "undefined") {
+/**
+ * hasFilterHandler
+ * - if testValue is undefined, checks to see if the chart has any active filters
+ * - if testValue is defined, checks to see if that testValue passes the active filter
+ *
+ * @param {*} filters - the chart's current filter
+ * @param {*} testValue - a value being tested to see if it passes the filter
+ *
+ *  - If chart values are not binned:
+ *      - Params will be an array of values
+ *      - e.g. [4,22,100] - and values 4, 22, and 100 will be selected in table chart
+ *        with all other values deselected
+ *  - If chart values are binned, params will be an array of arrays
+ *      - Inner arrays will represent a range of values
+ *      - e.g. [[19,27]] - the bin with values from 19 to 27 will be selected, with
+ *        all others being deselected
+ */
+function hasFilterHandler(filters, testValue) {
+  if (typeof testValue === "undefined") {
     return filters.length > 0;
-  } else if (Array.isArray(filter)) {
-    filter = filter.map(_formattingHelpers.normalizeArrayByValue);
-    return filters.some(function (f) {
-      return filter <= f && filter >= f;
-    });
-  } else {
-    return filters.some(function (f) {
-      return filter <= f && filter >= f;
+  }
+  testValue = Array.isArray(testValue) ? testValue.map(_formattingHelpers.normalizeArrayByValue) : testValue;
+  var filtersWithIsoDates = convertAllDatesToISOString(filters);
+  var testValueWithISODates = convertAllDatesToISOString(testValue);
+  return filtersWithIsoDates.some(function (f) {
+    return testValueWithISODates <= f && testValueWithISODates >= f;
+  });
+}
+
+function convertAllDatesToISOString(a) {
+  if (Array.isArray(a)) {
+    // Assuming array can only have up to one level of nested arrays
+    return a.map(function (value) {
+      if (Array.isArray(value)) {
+        return value.map(function (v) {
+          if (v instanceof Date) {
+            return v.toISOString();
+          }
+        });
+      }
+      return value instanceof Date ? value.toISOString() : value;
     });
   }
+  return a instanceof Date ? a.toISOString() : a;
 }
 
 function filterHandlerWithChartContext(_chart) {

--- a/src/mixins/filter-mixin.js
+++ b/src/mixins/filter-mixin.js
@@ -35,12 +35,7 @@ export function addFilterHandler(filters, filter) {
 export function hasFilterHandler(filters, testValue) {
   if (typeof testValue === "undefined") {
     return filters.length > 0
-  } else {
-    return testIfValueWithinFilters(filters, testValue)
   }
-}
-
-function testIfValueWithinFilters(filters, testValue) {
   testValue = Array.isArray(testValue)
     ? testValue.map(normalizeArrayByValue)
     : testValue

--- a/src/mixins/filter-mixin.js
+++ b/src/mixins/filter-mixin.js
@@ -44,25 +44,28 @@ function testIfValueWithinFilters(filters, testValue) {
   testValue = Array.isArray(testValue)
     ? testValue.map(normalizeArrayByValue)
     : testValue
-  const filtersWithIsoDates = convertAllDatesInArrayToISOString(filters)
-  const testValueWithISODates = convertAllDatesInArrayToISOString(testValue)
+  const filtersWithIsoDates = convertAllDatesToISOString(filters)
+  const testValueWithISODates = convertAllDatesToISOString(testValue)
   return filtersWithIsoDates.some(
     f => testValueWithISODates <= f && testValueWithISODates >= f
   )
 }
 
-// Assuming array can only have one level of nested arrays
-function convertAllDatesInArrayToISOString(a) {
-  return a.map(value => {
-    if (Array.isArray(value)) {
-      return value.map(v => {
-        if (v instanceof Date) {
-          return v.toISOString()
-        }
-      })
-    }
-    return value instanceof Date ? value.toISOString() : value
-  })
+function convertAllDatesToISOString(a) {
+  if (Array.isArray(a)) {
+    // Assuming array can only have up to one level of nested arrays
+    return a.map(value => {
+      if (Array.isArray(value)) {
+        return value.map(v => {
+          if (v instanceof Date) {
+            return v.toISOString()
+          }
+        })
+      }
+      return value instanceof Date ? value.toISOString() : value
+    })
+  }
+  return a instanceof Date ? a.toISOString() : a
 }
 
 export function filterHandlerWithChartContext(_chart) {

--- a/src/mixins/filter-mixin.js
+++ b/src/mixins/filter-mixin.js
@@ -15,15 +15,54 @@ export function addFilterHandler(filters, filter) {
   return filters
 }
 
-export function hasFilterHandler(filters, filter) {
-  if (typeof filter === "undefined") {
+/**
+ * hasFilterHandler
+ * - if testValue is undefined, checks to see if the chart has any active filters
+ * - if testValue is defined, checks to see if that testValue passes the active filter
+ *
+ * @param {*} filters - the chart's current filter
+ * @param {*} testValue - a value being tested to see if it passes the filter
+ *
+ *  - If chart values are not binned:
+ *      - Params will be an array of values
+ *      - e.g. [4,22,100] - and values 4, 22, and 100 will be selected in table chart
+ *        with all other values deselected
+ *  - If chart values are binned, params will be an array of arrays
+ *      - Inner arrays will represent a range of values
+ *      - e.g. [[19,27]] - the bin with values from 19 to 27 will be selected, with
+ *        all others being deselected
+ */
+export function hasFilterHandler(filters, testValue) {
+  if (typeof testValue === "undefined") {
     return filters.length > 0
-  } else if (Array.isArray(filter)) {
-    filter = filter.map(normalizeArrayByValue)
-    return filters.some(f => filter <= f && filter >= f)
   } else {
-    return filters.some(f => filter <= f && filter >= f)
+    return testIfValueWithinFilters(filters, testValue)
   }
+}
+
+function testIfValueWithinFilters(filters, testValue) {
+  testValue = Array.isArray(testValue)
+    ? testValue.map(normalizeArrayByValue)
+    : testValue
+  const filtersWithIsoDates = convertAllDatesInArrayToISOString(filters)
+  const testValueWithISODates = convertAllDatesInArrayToISOString(testValue)
+  return filtersWithIsoDates.some(
+    f => testValueWithISODates <= f && testValueWithISODates >= f
+  )
+}
+
+// Assuming array can only have one level of nested arrays
+function convertAllDatesInArrayToISOString(a) {
+  return a.map(value => {
+    if (Array.isArray(value)) {
+      return value.map(v => {
+        if (v instanceof Date) {
+          return v.toISOString()
+        }
+      })
+    }
+    return value instanceof Date ? value.toISOString() : value
+  })
 }
 
 export function filterHandlerWithChartContext(_chart) {

--- a/src/mixins/filter-mixin.js
+++ b/src/mixins/filter-mixin.js
@@ -24,10 +24,10 @@ export function addFilterHandler(filters, filter) {
  * @param {*} testValue - a value being tested to see if it passes the filter
  *
  *  - If chart values are not binned:
- *      - Params will be an array of values
+ *      - Params will most likely both be an array of values
  *      - e.g. [4,22,100] - and values 4, 22, and 100 will be selected in table chart
  *        with all other values deselected
- *  - If chart values are binned, params will be an array of arrays
+ *  - If chart values are binned, params will most likely both be an array of arrays
  *      - Inner arrays will represent a range of values
  *      - e.g. [[19,27]] - the bin with values from 19 to 27 will be selected, with
  *        all others being deselected


### PR DESCRIPTION
Dates were being coerced to strings that didn't include milliseconds, so now any dates in filters or test values are coerced to ISO strings when being compared.

Also added documentation and split up some code for readability.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
