### PR TITLE
[FE-8795] Fix auto binning for dates in heatmap with high precision timestamps 

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -28468,12 +28468,21 @@ function autoBinParams(timeBounds, maxNumBins, reverse) {
     return DEFAULT_NULL_TIME_RANGE;
   }
   var timeSpans = reverse ? TIME_SPANS.slice().reverse() : TIME_SPANS;
+  // Try to find a binning unit where the range is between 2 and the max bin #
   for (var s = 0; s < timeSpans.length; s++) {
     if (timeRange / timeSpans[s].numSeconds < maxNumBins && timeRange / timeSpans[s].numSeconds > 2) {
       return timeSpans[s].label;
     }
   }
-  return "century"; // default;
+
+  // In cases where the above doesn't exist, just try to find a bin unit
+  // that is under the max # bins
+  for (var _s = 0; _s < timeSpans.length; _s++) {
+    if (timeRange / timeSpans[_s].numSeconds < maxNumBins) {
+      return timeSpans[_s].label;
+    }
+  }
+  return "century"; // default
 }
 
 function checkIfTimeBinInRange(timeBounds, timeBin, maxNumBins) {
@@ -51638,10 +51647,10 @@ function addFilterHandler(filters, filter) {
  * @param {*} testValue - a value being tested to see if it passes the filter
  *
  *  - If chart values are not binned:
- *      - Params will be an array of values
+ *      - Params will most likely both be an array of values
  *      - e.g. [4,22,100] - and values 4, 22, and 100 will be selected in table chart
  *        with all other values deselected
- *  - If chart values are binned, params will be an array of arrays
+ *  - If chart values are binned, params will most likely both be an array of arrays
  *      - Inner arrays will represent a range of values
  *      - e.g. [[19,27]] - the bin with values from 19 to 27 will be selected, with
  *        all others being deselected

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -28468,18 +28468,10 @@ function autoBinParams(timeBounds, maxNumBins, reverse) {
     return DEFAULT_NULL_TIME_RANGE;
   }
   var timeSpans = reverse ? TIME_SPANS.slice().reverse() : TIME_SPANS;
-  // Try to find a binning unit where the range is between 2 and the max bin #
-  for (var s = 0; s < timeSpans.length; s++) {
-    if (timeRange / timeSpans[s].numSeconds < maxNumBins && timeRange / timeSpans[s].numSeconds > 2) {
-      return timeSpans[s].label;
-    }
-  }
 
-  // In cases where the above doesn't exist, just try to find a bin unit
-  // that is under the max # bins
-  for (var _s = 0; _s < timeSpans.length; _s++) {
-    if (timeRange / timeSpans[_s].numSeconds < maxNumBins) {
-      return timeSpans[_s].label;
+  for (var s = 0; s < timeSpans.length; s++) {
+    if (timeRange / timeSpans[s].numSeconds < maxNumBins) {
+      return timeSpans[s].label;
     }
   }
   return "century"; // default

--- a/src/utils/binning-helpers.js
+++ b/src/utils/binning-helpers.js
@@ -67,21 +67,6 @@ export function autoBinParams(timeBounds, maxNumBins, reverse) {
   }
   const timeSpans = reverse ? TIME_SPANS.slice().reverse() : TIME_SPANS
 
-  // First try to find a binning unit where the range is between 2 and the max bin #
-  for (let s = 0; s < timeSpans.length; s++) {
-    if (
-      timeRange / timeSpans[s].numSeconds < maxNumBins &&
-      timeRange / timeSpans[s].numSeconds > 2
-    ) {
-      return timeSpans[s].label
-    }
-  }
-
-  // In cases where the above doesn't exist, just try to find a bin unit
-  // that is under the max # bins.
-  // This can occur with millisecond time ranges on the heat chart, where there
-  // can be greater than 50 bins (max for heat chart) when binning by
-  // millisecond, but less than 2 bins when binning by seconds.
   for (let s = 0; s < timeSpans.length; s++) {
     if (timeRange / timeSpans[s].numSeconds < maxNumBins) {
       return timeSpans[s].label

--- a/src/utils/binning-helpers.js
+++ b/src/utils/binning-helpers.js
@@ -24,7 +24,7 @@ const TIME_LABELS = [
   "decade"
 ]
 
-const DEFAULT_NULL_TIME_RANGE = "day";
+const DEFAULT_NULL_TIME_RANGE = "day"
 
 export const TIME_LABEL_TO_SECS = {
   millisecond: MS_IN_SECS,
@@ -66,6 +66,7 @@ export function autoBinParams(timeBounds, maxNumBins, reverse) {
     return DEFAULT_NULL_TIME_RANGE
   }
   const timeSpans = reverse ? TIME_SPANS.slice().reverse() : TIME_SPANS
+  // Try to find a binning unit where the range is between 2 and the max bin #
   for (let s = 0; s < timeSpans.length; s++) {
     if (
       timeRange / timeSpans[s].numSeconds < maxNumBins &&
@@ -74,7 +75,15 @@ export function autoBinParams(timeBounds, maxNumBins, reverse) {
       return timeSpans[s].label
     }
   }
-  return "century" // default;
+
+  // In cases where the above doesn't exist, just try to find a bin unit
+  // that is under the max # bins
+  for (let s = 0; s < timeSpans.length; s++) {
+    if (timeRange / timeSpans[s].numSeconds < maxNumBins) {
+      return timeSpans[s].label
+    }
+  }
+  return "century" // default
 }
 
 export function checkIfTimeBinInRange(timeBounds, timeBin, maxNumBins) {

--- a/src/utils/binning-helpers.js
+++ b/src/utils/binning-helpers.js
@@ -66,7 +66,8 @@ export function autoBinParams(timeBounds, maxNumBins, reverse) {
     return DEFAULT_NULL_TIME_RANGE
   }
   const timeSpans = reverse ? TIME_SPANS.slice().reverse() : TIME_SPANS
-  // Try to find a binning unit where the range is between 2 and the max bin #
+
+  // First try to find a binning unit where the range is between 2 and the max bin #
   for (let s = 0; s < timeSpans.length; s++) {
     if (
       timeRange / timeSpans[s].numSeconds < maxNumBins &&
@@ -77,7 +78,10 @@ export function autoBinParams(timeBounds, maxNumBins, reverse) {
   }
 
   // In cases where the above doesn't exist, just try to find a bin unit
-  // that is under the max # bins
+  // that is under the max # bins.
+  // This can occur with millisecond time ranges on the heat chart, where there
+  // can be greater than 50 bins (max for heat chart) when binning by
+  // millisecond, but less than 2 bins when binning by seconds.
   for (let s = 0; s < timeSpans.length; s++) {
     if (timeRange / timeSpans[s].numSeconds < maxNumBins) {
       return timeSpans[s].label


### PR DESCRIPTION
This fixes a bug where heatmap was binning by century for high precision timestamp datasets. It's also relevant to know that heatmap's maximum bin number is 50.

When we automatically select a bin unit for a given dataset, we try to find a unit of time ( century, decade, year, quarter, month, week, day, hour, minute, second, millisecond) that would provide less than the max number of bins while also having greater than 2 bins.  I presume we added the minimum number of bins for charts like line chart, where two data points are required to render a line. 

There are edge cases where no units fit those parameters, in which case the chart defaults to binning by century. 

For example, with a high precision timestamp dataset that spans **140 milliseconds**:

- Binning by millisecond would create 140 bins, which is greater than the max number of bins for heat chart
- Binning by second would create 1 bin, which is less than the current minimum number of bins (2)

Because we iterate upward from smallest unit (millisecond) to largest unit (century), it doesn't make sense to also have a minimum number of bins in the check. Because, if there are insufficient bins for a given dataset when binning by a certain value (for example, minutes), the following unit in the iteration (hours) will never have additional bins. In which case, all we want to do is make sure we have the smallest binning unit that is within the maximum number of bins. 