### PR TITLE
[FE-8727][FE-8787] Fix Heat chart x-axis labels, popups display when specifying custom date format

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -66905,30 +66905,48 @@ function heatMapValueAccesor(_ref2) {
 
 function heatMapRowsLabel(d) {
   var value = this.rowsMap.get(d) || d;
-  var valueIsFormattableDate = false;
 
+  // There will only return a value if we're displaying dates
   var customFormatter = this.dateFormatter();
+
+  // Possibly dead code, `d` should always be a string
   if (customFormatter && d && d instanceof Date) {
-    valueIsFormattableDate = true;
     if (Array.isArray(value) && value[0]) {
       value = value[0].value || value[0];
     }
   }
 
-  return valueIsFormattableDate && customFormatter && customFormatter(value, this.yAxisLabel()) || (0, _formattingHelpers.formatDataValue)(value);
+  // customFormatter is set to autoFormatter (mapd3), which processes raw values
+  // whereas formatDataValue expects an object / array of objects that contain
+  // additional information
+  var rawValues = Array.isArray(value) ? value.map(function (v) {
+    return v.value;
+  }) : null;
+
+  return customFormatter && customFormatter(rawValues || value, this.yAxisLabel()) || (0, _formattingHelpers.formatDataValue)(value);
 }
 
 function heatMapColsLabel(d) {
   var value = this.colsMap.get(d) || d;
 
+  // There will only return a value if we're displaying dates
   var customFormatter = this.dateFormatter();
+
+  // Possibly dead code, `d` should always be a string
   if (customFormatter && d && d instanceof Date) {
     if (Array.isArray(value) && value[0]) {
       value = value[0].value || value[0];
     }
   }
 
-  return customFormatter && customFormatter(value, this.xAxisLabel()) || (0, _formattingHelpers.formatDataValue)(value);
+  // customFormatter is set to `autoFormatter` (mapd3), which processes raw values.
+  // Whereas formatDataValue expects an object / array of objects that contain
+  // additional information
+  var rawValues = Array.isArray(value) ? value.map(function (v) {
+    return v.value;
+  }) : null;
+
+  return customFormatter && customFormatter(rawValues || value, this.xAxisLabel()) || (0, _formattingHelpers.formatDataValue)(value);
 }
 
 function isDescendingAppropriateData(_ref3) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4925,8 +4925,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4947,14 +4946,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4969,20 +4966,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5099,8 +5093,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5112,7 +5105,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5127,7 +5119,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5135,14 +5126,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5161,7 +5150,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5249,8 +5237,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5262,7 +5249,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5348,8 +5334,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5385,7 +5370,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5405,7 +5389,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5449,14 +5432,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -8838,7 +8819,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9588,8 +9568,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/src/charts/heatmap.js
+++ b/src/charts/heatmap.js
@@ -59,34 +59,52 @@ export function heatMapValueAccesor({ key1 }) {
 
 export function heatMapRowsLabel(d) {
   let value = this.rowsMap.get(d) || d
-  let valueIsFormattableDate = false
 
+  // There will only return a value if we're displaying dates
   const customFormatter = this.dateFormatter()
+
+  // Possibly dead code, `d` should always be a string
   if (customFormatter && d && d instanceof Date) {
-    valueIsFormattableDate = true
     if (Array.isArray(value) && value[0]) {
       value = value[0].value || value[0]
     }
   }
 
+  // customFormatter is set to autoFormatter (mapd3), which processes raw values
+  // whereas formatDataValue expects an object / array of objects that contain
+  // additional information
+  const rawValues = Array.isArray(value) ? value.map(v => v.value) : null
+
   return (
-      valueIsFormattableDate &&
-      customFormatter &&
-      customFormatter(value, this.yAxisLabel())
-    ) || formatDataValue(value)
+    (customFormatter &&
+      customFormatter(rawValues || value, this.yAxisLabel())) ||
+    formatDataValue(value)
+  )
 }
 
 export function heatMapColsLabel(d) {
   let value = this.colsMap.get(d) || d
 
+  // There will only return a value if we're displaying dates
   const customFormatter = this.dateFormatter()
+
+  // Possibly dead code, `d` should always be a string
   if (customFormatter && d && d instanceof Date) {
     if (Array.isArray(value) && value[0]) {
       value = value[0].value || value[0]
     }
   }
 
-  return (customFormatter && customFormatter(value, this.xAxisLabel())) || formatDataValue(value)
+  // customFormatter is set to `autoFormatter` (mapd3), which processes raw values.
+  // Whereas formatDataValue expects an object / array of objects that contain
+  // additional information
+  const rawValues = Array.isArray(value) ? value.map(v => v.value) : null
+
+  return (
+    (customFormatter &&
+      customFormatter(rawValues || value, this.xAxisLabel())) ||
+    formatDataValue(value)
+  )
 }
 
 export function isDescendingAppropriateData({ key1 }) {


### PR DESCRIPTION
Custom dimension date formats weren't appearing correctly in heat chart - both in axis labels and popups. 

This is because the functions that created the text for rows / columns in the heat chart were passing along the information in the incorrect format. 

`customFormatter` is set to the `autoFormatter` function from mapd3, which processes raw values. However, `formatDataValue` expects an object / array of objects that contain additional information
