### PR TITLE
[FE-8842] Normalize table and column alias SQL to use uppercase AS

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -5163,9 +5163,9 @@ function hexBinSQL(sql, _ref, parser) {
 
   var args = parser.parseExpression(x.field) + "," + (hexminmercx + ",") + (hexmaxmercx + ",") + (parser.parseExpression(y.field) + ",") + (hexminmercy + ",") + (hexmaxmercy + ",") + (mark.width + ",") + (mark.height + ",") + (hexoffsetx + ",") + (hexoffsety + ",") + (width + ",") + ("" + height);
 
-  sql.select.push("reg_" + mark.shape + "_horiz_pixel_bin_x(" + args + ") as x");
-  sql.select.push("reg_" + mark.shape + "_horiz_pixel_bin_y(" + args + ") as y");
-  sql.select.push(parser.parseExpression(aggregate) + " as color");
+  sql.select.push("reg_" + mark.shape + "_horiz_pixel_bin_x(" + args + ") AS x");
+  sql.select.push("reg_" + mark.shape + "_horiz_pixel_bin_y(" + args + ") AS y");
+  sql.select.push(parser.parseExpression(aggregate) + " AS color");
   sql.groupby.push("x");
   sql.groupby.push("y");
 
@@ -5180,9 +5180,9 @@ function rectBinSQL(sql, _ref2, parser) {
       y = _ref2.y,
       aggregate = _ref2.aggregate;
 
-  sql.select.push("rect_pixel_bin_x(" + parser.parseExpression(x.field) + ", " + x.domain[0] + ", " + x.domain[1] + ", " + mark.width + ", 0, " + width + ") as x");
-  sql.select.push("rect_pixel_bin_y(" + parser.parseExpression(y.field) + ", " + y.domain[0] + ", " + y.domain[1] + ", " + mark.height + ", 0, " + height + ") as y");
-  sql.select.push(parser.parseExpression(aggregate) + " as color");
+  sql.select.push("rect_pixel_bin_x(" + parser.parseExpression(x.field) + ", " + x.domain[0] + ", " + x.domain[1] + ", " + mark.width + ", 0, " + width + ") AS x");
+  sql.select.push("rect_pixel_bin_y(" + parser.parseExpression(y.field) + ", " + y.domain[0] + ", " + y.domain[1] + ", " + mark.height + ", 0, " + height + ") AS y");
+  sql.select.push(parser.parseExpression(aggregate) + " AS color");
   sql.groupby.push("x");
   sql.groupby.push("y");
 
@@ -31376,7 +31376,7 @@ function parseSource(transforms) {
       var joinType = typeof transform.type === "string" ? transform.type : "join";
       // $FlowFixMe
       var joinStmt = left + " " + joinRelation(joinType) + " " + right;
-      var aliasStmt = typeof transform.as === "string" ? " as " + transform.as : "";
+      var aliasStmt = typeof transform.as === "string" ? " AS " + transform.as : "";
       return stmt.concat(joinStmt + aliasStmt);
     } else if (transform.type === "data" || transform.type === "root") {
       // $FlowFixMe
@@ -49859,7 +49859,7 @@ function aggregateField(op, field, as) {
     str += op + "(" + field + ")";
   }
 
-  return str + ("" + (as ? " as " + as : ""));
+  return str + ("" + (as ? " AS " + as : ""));
 }
 
 function parseGroupBy(sql, groupby, parser) {
@@ -49870,7 +49870,7 @@ function parseGroupBy(sql, groupby, parser) {
     sql = parser.parseTransform(sql, groupby);
     sql.groupby.push(groupby.as);
   } else if (groupby.type === "project") {
-    sql.select.push(parser.parseExpression(groupby.expr) + (groupby.as ? " as " + groupby.as : ""));
+    sql.select.push(parser.parseExpression(groupby.expr) + (groupby.as ? " AS " + groupby.as : ""));
     if (groupby.as) {
       sql.groupby.push(groupby.as);
     }
@@ -49904,7 +49904,7 @@ function parseBin(sql, _ref) {
   // The logic used by mapd-crossfilter's getBinnedDimExpression is completely different.
   var numBins = extent[1] - extent[0];
 
-  sql.select.push("case when\n      " + field + " >= " + extent[1] + "\n    then\n      " + (numBins === 0 ? 0 : maxbins - 1) + "\n    else\n      cast((cast(" + field + " as float) - " + extent[0] + ") * " + maxbins / (numBins || 1) + " as int)\n    end\n    as " + as);
+  sql.select.push("case when\n      " + field + " >= " + extent[1] + "\n    then\n      " + (numBins === 0 ? 0 : maxbins - 1) + "\n    else\n      cast((cast(" + field + " as float) - " + extent[0] + ") * " + maxbins / (numBins || 1) + " as int)\n    end\n    AS " + as);
   sql.where.push("((" + field + " >= " + extent[0] + " AND " + field + " <= " + extent[1] + ") OR (" + field + " IS NULL))");
   sql.having.push("(" + as + " >= 0 AND " + as + " < " + maxbins + " OR " + as + " IS NULL)");
   return sql;
@@ -50043,7 +50043,7 @@ function parsePostFilter(sql, transform) {
 function parseProject(sql, transform) {
   var parser = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : __WEBPACK_IMPORTED_MODULE_0__create_parser__["b" /* default */];
 
-  sql.select.push(parser.parseExpression(transform.expr) + (transform.as ? " as " + transform.as : ""));
+  sql.select.push(parser.parseExpression(transform.expr) + (transform.as ? " AS " + transform.as : ""));
   return sql;
 }
 
@@ -69364,7 +69364,7 @@ function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
     var geoTable = _layer.getState().encoding.geoTable;
     var geoCol = _layer.getState().encoding.geocol;
 
-    var preflightQuery = "SELECT COUNT(*) as n FROM " + geoTable + " WHERE ST_XMax(" + geoTable + "." + geoCol + ") >= " + mapBounds._sw.lng + " AND ST_XMin(" + geoTable + "." + geoCol + ") <= " + mapBounds._ne.lng + " AND ST_YMax(" + geoTable + "." + geoCol + ") >= " + mapBounds._sw.lat + " AND ST_YMin(" + geoTable + "." + geoCol + ") <= " + mapBounds._ne.lat;
+    var preflightQuery = "SELECT COUNT(*) AS n FROM " + geoTable + " WHERE ST_XMax(" + geoTable + "." + geoCol + ") >= " + mapBounds._sw.lng + " AND ST_XMin(" + geoTable + "." + geoCol + ") <= " + mapBounds._ne.lng + " AND ST_YMax(" + geoTable + "." + geoCol + ") >= " + mapBounds._sw.lat + " AND ST_YMin(" + geoTable + "." + geoCol + ") <= " + mapBounds._ne.lat;
 
     return chart.con().queryAsync(preflightQuery, {});
   }
@@ -73617,8 +73617,8 @@ var SCROLL_DIVISOR = 5;
 
 var splitStrOnLastAs = exports.splitStrOnLastAs = function splitStrOnLastAs(str) {
   var splitStr = [];
-  splitStr[0] = str.substring(0, str.lastIndexOf("as") - 1);
-  splitStr[1] = str.substring(str.lastIndexOf("as") + 3, str.length);
+  splitStr[0] = str.substring(0, str.lastIndexOf("AS") - 1);
+  splitStr[1] = str.substring(str.lastIndexOf("AS") + 3, str.length);
   return splitStr;
 };
 
@@ -76153,11 +76153,11 @@ function rasterMixin(_chart) {
     var columns = _chart.popupColumns().slice();
 
     if (typeof _chart.useLonLat === "function" && _chart.useLonLat()) {
-      columns.push("conv_4326_900913_x(" + _chart._xDimName + ") as xPoint");
-      columns.push("conv_4326_900913_y(" + _chart._yDimName + ") as yPoint");
+      columns.push("conv_4326_900913_x(" + _chart._xDimName + ") AS xPoint");
+      columns.push("conv_4326_900913_y(" + _chart._yDimName + ") AS yPoint");
     } else {
-      columns.push(_chart._xDimName + " as xPoint");
-      columns.push(_chart._yDimName + " as yPoint");
+      columns.push(_chart._xDimName + " AS xPoint");
+      columns.push(_chart._yDimName + " AS yPoint");
     }
 
     if (_chart.colorBy() && columns.indexOf(_chart.colorBy().value) === -1) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
       }
     },
     "@mapd/crossfilter": {
-      "version": "github:omnisci/mapd-crossfilter#02c82d27ec4b35e81ded83cf87522168bfcb5e0b",
-      "from": "github:omnisci/mapd-crossfilter#02c82d2",
+      "version": "github:omnisci/mapd-crossfilter#a712c3f298705667cb51769850979d6d707a51e6",
+      "from": "github:omnisci/mapd-crossfilter#a712c3f",
       "dev": true
     },
     "@mapd/mapd-draw": {
@@ -4920,7 +4920,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4941,12 +4942,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4961,17 +4964,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5088,7 +5094,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5100,6 +5107,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5114,6 +5122,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5121,12 +5130,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5145,6 +5156,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5232,7 +5244,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5244,6 +5257,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5329,7 +5343,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5365,6 +5380,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5384,6 +5400,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5427,12 +5444,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -7732,9 +7751,9 @@
       "integrity": "sha1-y9NN+JQgbK3amjPI2aRgnya7GYk="
     },
     "mapd-data-layer-2": {
-      "version": "0.0.21",
-      "resolved": "https://registry.npmjs.org/mapd-data-layer-2/-/mapd-data-layer-2-0.0.21.tgz",
-      "integrity": "sha512-loupAjDLEXFeHdDXJk9IqDwKQSp1OhLdIbSqIM0YRQJ5aeAK7ru3XQ5eHvy1LbhXaOEmYOmMKkQDkmrNX531Pg==",
+      "version": "0.0.22",
+      "resolved": "https://registry.npmjs.org/mapd-data-layer-2/-/mapd-data-layer-2-0.0.22.tgz",
+      "integrity": "sha512-qH8AjX9rMcF2ncBchmhj0GwnckAH7rja65pdzI6PBq1BrPn2YE8ERlcDqT9EpYdVayFTTd21SeBOOGgMVhwn2Q==",
       "requires": {
         "invariant": "^2.2.2"
       }
@@ -8825,6 +8844,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9574,7 +9594,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "http-server": "^0.11.1",
     "legendables": "git://github.com/omnisci/legendables.git#63e2ad9a8375a11e5510a5dadf0b7a4326fae888",
     "mapbox-gl": "https://github.com/omnisci/mapbox-gl-js/tarball/6389d23f212ef9fd8f7cd886578cfdb3dbd88746",
-    "mapd-data-layer-2": "0.0.21",
+    "mapd-data-layer-2": "0.0.22",
     "moment": "^2.19.3",
     "ramda": "0.21.0",
     "simplify-js": "^1.2.1",
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@mapd/connector": "omnisci/mapd-connector#cbd4377",
-    "@mapd/crossfilter": "omnisci/mapd-crossfilter#02c82d2",
+    "@mapd/crossfilter": "omnisci/mapd-crossfilter#a712c3f",
     "atob": "^2.0.3",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",

--- a/src/charts/mapd-table.js
+++ b/src/charts/mapd-table.js
@@ -13,8 +13,8 @@ const SCROLL_DIVISOR = 5
 
 export const splitStrOnLastAs = str => {
   const splitStr = []
-  splitStr[0] = str.substring(0, str.lastIndexOf("as") - 1)
-  splitStr[1] = str.substring(str.lastIndexOf("as") + 3, str.length)
+  splitStr[0] = str.substring(0, str.lastIndexOf("AS") - 1)
+  splitStr[1] = str.substring(str.lastIndexOf("AS") + 3, str.length)
   return splitStr
 }
 
@@ -344,8 +344,14 @@ export default function mapdTable(parent, chartGroup) {
             customFormatter = _chart.valueFormatter()
           }
 
-          const key = (val && val[0] && val[0].isExtract) ? null : col.measureName || col.expression
-          return customFormatter && customFormatter(val, key) || formatDataValue(val)
+          const key =
+            val && val[0] && val[0].isExtract
+              ? null
+              : col.measureName || col.expression
+          return (
+            (customFormatter && customFormatter(val, key)) ||
+            formatDataValue(val)
+          )
         })
         .classed("filtered", col.expression in _filteredColumns)
         .on("click", d => {

--- a/src/charts/mapd-table.unit.spec.js
+++ b/src/charts/mapd-table.unit.spec.js
@@ -13,7 +13,7 @@ describe("MapD Table Chart", () => {
   describe("splitStrOnLastAs", () => {
     it("should properly split on last AS within SQL statement", () => {
       const sqlStatement =
-        "cast(SUM(CASE WHEN Shot_result = 'made' THEN 1 ELSE 0 END) as float)/(cast(SUM(CASE WHEN Shot_result = 'missed' THEN 1 ELSE 0 END) as float) + cast(SUM(CASE WHEN Shot_result = 'made' THEN 1 ELSE 0 END) as float)) as col3"
+        "cast(SUM(CASE WHEN Shot_result = 'made' THEN 1 ELSE 0 END) as float)/(cast(SUM(CASE WHEN Shot_result = 'missed' THEN 1 ELSE 0 END) as float) + cast(SUM(CASE WHEN Shot_result = 'made' THEN 1 ELSE 0 END) as float)) AS col3"
       const result = splitStrOnLastAs(sqlStatement)
       expect(result).to.deep.equal([
         "cast(SUM(CASE WHEN Shot_result = 'made' THEN 1 ELSE 0 END) as float)/(cast(SUM(CASE WHEN Shot_result = 'missed' THEN 1 ELSE 0 END) as float) + cast(SUM(CASE WHEN Shot_result = 'made' THEN 1 ELSE 0 END) as float))",

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -269,7 +269,7 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
     const geoTable = _layer.getState().encoding.geoTable
     const geoCol = _layer.getState().encoding.geocol
 
-    const preflightQuery = `SELECT COUNT(*) as n FROM ${geoTable} WHERE ST_XMax(${geoTable}.${geoCol}) >= ${ mapBounds._sw.lng } AND ST_XMin(${geoTable}.${geoCol}) <= ${ mapBounds._ne.lng } AND ST_YMax(${geoTable}.${geoCol}) >= ${ mapBounds._sw.lat } AND ST_YMin(${geoTable}.${geoCol}) <= ${ mapBounds._ne.lat }`
+    const preflightQuery = `SELECT COUNT(*) AS n FROM ${geoTable} WHERE ST_XMax(${geoTable}.${geoCol}) >= ${ mapBounds._sw.lng } AND ST_XMin(${geoTable}.${geoCol}) <= ${ mapBounds._ne.lng } AND ST_YMax(${geoTable}.${geoCol}) >= ${ mapBounds._sw.lat } AND ST_YMin(${geoTable}.${geoCol}) <= ${ mapBounds._ne.lat }`
 
     return chart.con().queryAsync(preflightQuery, {})
   }

--- a/src/mixins/raster-layer-heatmap.unit.spec.js
+++ b/src/mixins/raster-layer-heatmap.unit.spec.js
@@ -76,9 +76,9 @@ describe("rasterLayerHeatmapMixin", () => {
           {
             name: "heatmap_query",
             sql:
-              "SELECT rect_pixel_bin_x(conv_4326_900913_x(lon), -50, -50, 1, 0, 100) as x, " +
-              "rect_pixel_bin_y(conv_4326_900913_y(lat), 50, 50, 1, 0, 100) as y, " +
-              "count(*) as color FROM tweets_nov_feb WHERE (lon = 100) GROUP BY x, y"
+              "SELECT rect_pixel_bin_x(conv_4326_900913_x(lon), -50, -50, 1, 0, 100) AS x, " +
+              "rect_pixel_bin_y(conv_4326_900913_y(lat), 50, 50, 1, 0, 100) AS y, " +
+              "count(*) AS color FROM tweets_nov_feb WHERE (lon = 100) GROUP BY x, y"
           }
         ],
         scales: [
@@ -138,9 +138,9 @@ describe("rasterLayerHeatmapMixin", () => {
           {
             name: "heatmap_query",
             sql:
-              "SELECT reg_hex_horiz_pixel_bin_x(conv_4326_900913_x(lon),-50,-50,conv_4326_900913_y(lat),50,50,1,1.1547005383792517,0,0,100,100) as x, " +
-              "reg_hex_horiz_pixel_bin_y(conv_4326_900913_x(lon),-50,-50,conv_4326_900913_y(lat),50,50,1,1.1547005383792517,0,0,100,100) as y, " +
-              "count(*) as color FROM tweets_nov_feb WHERE (lon = 100) GROUP BY x, y"
+              "SELECT reg_hex_horiz_pixel_bin_x(conv_4326_900913_x(lon),-50,-50,conv_4326_900913_y(lat),50,50,1,1.1547005383792517,0,0,100,100) AS x, " +
+              "reg_hex_horiz_pixel_bin_y(conv_4326_900913_x(lon),-50,-50,conv_4326_900913_y(lat),50,50,1,1.1547005383792517,0,0,100,100) AS y, " +
+              "count(*) AS color FROM tweets_nov_feb WHERE (lon = 100) GROUP BY x, y"
           }
         ],
         width: 100,

--- a/src/mixins/raster-layer-point-mixin.unit.spec.js
+++ b/src/mixins/raster-layer-point-mixin.unit.spec.js
@@ -82,7 +82,7 @@ describe("rasterLayerPointMixin", () => {
           data: [
             {
               name: "points",
-              sql: "SELECT conv_4326_900913_x(lon) as x, conv_4326_900913_y(lat) as y, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100)"
+              sql: "SELECT conv_4326_900913_x(lon) AS x, conv_4326_900913_y(lat) AS y, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100)"
             }
           ],
           "scales": [],
@@ -136,8 +136,8 @@ describe("rasterLayerPointMixin", () => {
           pixelRatio: 1,
           layerName: "points"
         }).data[0].sql).to.equal(
-          "SELECT conv_4326_900913_x(lon) as x, "
-          + "conv_4326_900913_y(lat) as y, "
+          "SELECT conv_4326_900913_x(lon) AS x, "
+          + "conv_4326_900913_y(lat) AS y, "
           + "tweets_nov_feb.rowid FROM tweets_nov_feb "
           + "WHERE MOD( MOD (tweets_nov_feb.rowid, 2147483648) * 2654435761 , 4294967296) < 7222804 "
           + "AND (lon = 100) LIMIT 2000000"
@@ -167,7 +167,7 @@ describe("rasterLayerPointMixin", () => {
           data: [
             {
               name: "points",
-              sql: "SELECT conv_4326_900913_x(lon) as x, conv_4326_900913_y(lat) as y, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100)"
+              sql: "SELECT conv_4326_900913_x(lon) AS x, conv_4326_900913_y(lat) AS y, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100)"
             }
           ],
           "scales": [],
@@ -288,7 +288,7 @@ describe("rasterLayerPointMixin", () => {
           data: [
             {
               name: "points",
-              sql: "SELECT conv_4326_900913_x(lon) as x, conv_4326_900913_y(lat) as y, tweet_count as size, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100)"
+              sql: "SELECT conv_4326_900913_x(lon) AS x, conv_4326_900913_y(lat) AS y, tweet_count AS size, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100)"
             }
           ],
           "scales": [
@@ -365,7 +365,7 @@ describe("rasterLayerPointMixin", () => {
           data: [
             {
               name: "points",
-              sql: "SELECT conv_4326_900913_x(lon) as x, conv_4326_900913_y(lat) as y, tweet_count as size, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100) LIMIT 2000000"
+              sql: "SELECT conv_4326_900913_x(lon) AS x, conv_4326_900913_y(lat) AS y, tweet_count AS size, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100) LIMIT 2000000"
             },
             {
               name: "points_stats",
@@ -463,7 +463,7 @@ describe("rasterLayerPointMixin", () => {
           data: [
             {
               name: "points",
-              sql: "SELECT conv_4326_900913_x(lon) as x, conv_4326_900913_y(lat) as y, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100)"
+              sql: "SELECT conv_4326_900913_x(lon) AS x, conv_4326_900913_y(lat) AS y, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100)"
             }
           ],
           "scales": [
@@ -553,7 +553,7 @@ describe("rasterLayerPointMixin", () => {
           data: [
             {
               name: "points",
-              sql: "SELECT conv_4326_900913_x(lon) as x, conv_4326_900913_y(lat) as y, party as color, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100)"
+              sql: "SELECT conv_4326_900913_x(lon) AS x, conv_4326_900913_y(lat) AS y, party AS color, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100)"
             }
           ],
           "scales": [
@@ -624,7 +624,7 @@ describe("rasterLayerPointMixin", () => {
           data: [
             {
               name: "points",
-              sql: "SELECT conv_4326_900913_x(lon) as x, conv_4326_900913_y(lat) as y, party as color, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100)"
+              sql: "SELECT conv_4326_900913_x(lon) AS x, conv_4326_900913_y(lat) AS y, party AS color, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100)"
             }
           ],
           "scales": [
@@ -694,7 +694,7 @@ describe("rasterLayerPointMixin", () => {
           data: [
             {
               name: "points",
-              sql: "SELECT conv_4326_900913_x(lon) as x, conv_4326_900913_y(lat) as y, tweet_count as color, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100) LIMIT 2000000"
+              sql: "SELECT conv_4326_900913_x(lon) AS x, conv_4326_900913_y(lat) AS y, tweet_count AS color, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100) LIMIT 2000000"
             },
             {
               name: "points_stats",
@@ -783,7 +783,7 @@ describe("rasterLayerPointMixin", () => {
           data: [
             {
               name: "points",
-              sql: "SELECT conv_4326_900913_x(lon) as x, conv_4326_900913_y(lat) as y, party as color, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100) LIMIT 2000000"
+              sql: "SELECT conv_4326_900913_x(lon) AS x, conv_4326_900913_y(lat) AS y, party AS color, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100) LIMIT 2000000"
             },
             {
               name: "points_stats",
@@ -870,7 +870,7 @@ describe("rasterLayerPointMixin", () => {
           data: [
             {
               name: "points",
-              sql: "SELECT conv_4326_900913_x(lon) as x, conv_4326_900913_y(lat) as y, tweet_count as size, party as color, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100) LIMIT 2000000"
+              sql: "SELECT conv_4326_900913_x(lon) AS x, conv_4326_900913_y(lat) AS y, tweet_count AS size, party AS color, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100) LIMIT 2000000"
             },
             {
               name: "points_stats",
@@ -981,7 +981,7 @@ describe("rasterLayerPointMixin", () => {
           data: [
             {
               name: "points",
-              sql: "SELECT conv_4326_900913_x(lon) as x, conv_4326_900913_y(lat) as y, tweet_count as size, tweet_count as color, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100) LIMIT 2000000"
+              sql: "SELECT conv_4326_900913_x(lon) AS x, conv_4326_900913_y(lat) AS y, tweet_count AS size, tweet_count AS color, tweets_nov_feb.rowid FROM tweets_nov_feb WHERE (lon = 100) LIMIT 2000000"
             },
             {
               name: "points_stats",
@@ -1108,9 +1108,9 @@ describe("rasterLayerPointMixin", () => {
       })
 
       expect(layer.getProjections()).to.deep.equal([
-        "conv_4326_900913_x(lon) as x",
-        "conv_4326_900913_y(lat) as y",
-        "party as color"
+        "conv_4326_900913_x(lon) AS x",
+        "conv_4326_900913_y(lat) AS y",
+        "party AS color"
       ])
     })
   })

--- a/src/mixins/raster-layer-poly-mixin.unit.spec.js
+++ b/src/mixins/raster-layer-poly-mixin.unit.spec.js
@@ -92,7 +92,7 @@ describe("rasterLayerPolyMixin", () => {
             name: "polys",
             format: "polys",
             sql:
-              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode as key0, AVG(contributions_donotmodify.amount) as color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo as mapd_geo, colors.key0 as key0, colors.color as color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)"
+              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)"
           }
         ],
         scales: [
@@ -194,7 +194,7 @@ describe("rasterLayerPolyMixin", () => {
             name: "polys",
             format: "polys",
             sql:
-              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode as key0, AVG(contributions_donotmodify.amount) as color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo as mapd_geo, colors.key0 as key0, colors.color as color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)"
+              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)"
           }
         ],
         scales: [
@@ -295,7 +295,7 @@ describe("rasterLayerPolyMixin", () => {
             name: "polys",
             format: "polys",
             sql:
-              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode as key0, AVG(contributions_donotmodify.amount) as color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo as mapd_geo, colors.key0 as key0, colors.color as color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)"
+              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)"
           }
         ],
         scales: [
@@ -393,7 +393,7 @@ describe("rasterLayerPolyMixin", () => {
             name: "polys",
             format: "polys",
             sql:
-              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode as key0, AVG(contributions_donotmodify.amount) as color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo as mapd_geo, colors.key0 as key0, colors.color as color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)"
+              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)"
           },
           {
             name: "polys_stats",

--- a/src/mixins/raster-mixin.js
+++ b/src/mixins/raster-mixin.js
@@ -422,11 +422,11 @@ export default function rasterMixin(_chart) {
     const columns = _chart.popupColumns().slice()
 
     if (typeof _chart.useLonLat === "function" && _chart.useLonLat()) {
-      columns.push("conv_4326_900913_x(" + _chart._xDimName + ") as xPoint")
-      columns.push("conv_4326_900913_y(" + _chart._yDimName + ") as yPoint")
+      columns.push("conv_4326_900913_x(" + _chart._xDimName + ") AS xPoint")
+      columns.push("conv_4326_900913_y(" + _chart._yDimName + ") AS yPoint")
     } else {
-      columns.push(_chart._xDimName + " as xPoint")
-      columns.push(_chart._yDimName + " as yPoint")
+      columns.push(_chart._xDimName + " AS xPoint")
+      columns.push(_chart._yDimName + " AS yPoint")
     }
 
     if (_chart.colorBy() && columns.indexOf(_chart.colorBy().value) === -1) {

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -23,13 +23,13 @@ function hexBinSQL(sql, { width, height, mark, x, y, aggregate }, parser) {
   let hexmaxmercy = y.domain[1]
 
   if (hexoffsetx) {
-    const mercxdiff = hexoffsetx * (hexmaxmercx - hexminmercx) / heximgwidth
+    const mercxdiff = (hexoffsetx * (hexmaxmercx - hexminmercx)) / heximgwidth
     hexminmercx = hexminmercx - mercxdiff
     hexmaxmercx = hexmaxmercx - mercxdiff
   }
 
   if (hexoffsety) {
-    const mercydiff = hexoffsety * (hexmaxmercy - hexminmercy) / heximgheight
+    const mercydiff = (hexoffsety * (hexmaxmercy - hexminmercy)) / heximgheight
     hexminmercy = hexminmercy - mercydiff
     hexmaxmercy = hexmaxmercy - mercydiff
   }
@@ -48,9 +48,9 @@ function hexBinSQL(sql, { width, height, mark, x, y, aggregate }, parser) {
     `${width},` +
     `${height}`
 
-  sql.select.push(`reg_${mark.shape}_horiz_pixel_bin_x(${args}) as x`)
-  sql.select.push(`reg_${mark.shape}_horiz_pixel_bin_y(${args}) as y`)
-  sql.select.push(`${parser.parseExpression(aggregate)} as color`)
+  sql.select.push(`reg_${mark.shape}_horiz_pixel_bin_x(${args}) AS x`)
+  sql.select.push(`reg_${mark.shape}_horiz_pixel_bin_y(${args}) AS y`)
+  sql.select.push(`${parser.parseExpression(aggregate)} AS color`)
   sql.groupby.push("x")
   sql.groupby.push("y")
 
@@ -61,14 +61,14 @@ function rectBinSQL(sql, { width, height, mark, x, y, aggregate }, parser) {
   sql.select.push(
     `rect_pixel_bin_x(${parser.parseExpression(x.field)}, ${x.domain[0]}, ${
       x.domain[1]
-    }, ${mark.width}, 0, ${width}) as x`
+    }, ${mark.width}, 0, ${width}) AS x`
   )
   sql.select.push(
     `rect_pixel_bin_y(${parser.parseExpression(y.field)}, ${y.domain[0]}, ${
       y.domain[1]
-    }, ${mark.height}, 0, ${height}) as y`
+    }, ${mark.height}, 0, ${height}) AS y`
   )
-  sql.select.push(`${parser.parseExpression(aggregate)} as color`)
+  sql.select.push(`${parser.parseExpression(aggregate)} AS color`)
   sql.groupby.push("x")
   sql.groupby.push("y")
 
@@ -391,7 +391,9 @@ utils.b64toBlob = function(b64Data, contentType, sliceSize) {
 utils.getFontSizeFromWidth = function(text, chartWidth, chartHeight) {
   const BASE_FONT_SIZE = 12
   const MIN_FONT_SIZE = 4
-  const tmpText = d3.select("body").append("span")
+  const tmpText = d3
+    .select("body")
+    .append("span")
     .attr("class", "tmp-text")
     .style("font-size", BASE_FONT_SIZE + "px")
     .style("position", "absolute")
@@ -410,8 +412,8 @@ utils.getFontSizeFromWidth = function(text, chartWidth, chartHeight) {
 
   tmpText.remove()
 
-  const fontSizeWidth = BASE_FONT_SIZE * chartWidth / textWidth
-  const fontSizeHeight = BASE_FONT_SIZE * chartHeight / textHeight
+  const fontSizeWidth = (BASE_FONT_SIZE * chartWidth) / textWidth
+  const fontSizeHeight = (BASE_FONT_SIZE * chartHeight) / textHeight
 
   return Math.max(Math.min(fontSizeWidth, fontSizeHeight), MIN_FONT_SIZE)
 }


### PR DESCRIPTION
Normalize SQL building to use uppercase 'AS' for table and column aliases, to be consistent with other modules. Pulls in mapd-crossfilter and metis (mapd-data-layer) changes for the same.