### PR TITLE
[FE-8788] Fix axis tick date formatting for HPT datasets in heat chart

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -7942,6 +7942,10 @@ function formatTimeBinValue(data) {
     case "hour":
     case "minute":
       return momentUTCFormat(startTime.value, "MMM D, YYYY") + " \u205F" + momentUTCFormat(startTime.value, "HH:mm");
+    case "second":
+      return "" + momentUTCFormat(startTime.value, "HH:mm:ss");
+    case "millisecond":
+      return "" + momentUTCFormat(startTime.value, "HH:mm:ss.SSS");
     default:
       return genericDateTimeFormat(startTime.value);
   }
@@ -66937,50 +66941,52 @@ function heatMapValueAccesor(_ref2) {
   }
 }
 
-function heatMapRowsLabel(d) {
-  var value = this.rowsMap.get(d) || d;
+function heatMapRowsLabel(key) {
+  // If the data is binned, this will be an array
+  var value = this.rowsMap.get(key) || key;
 
-  // There will only return a value if we're displaying dates
-  var customFormatter = this.dateFormatter();
+  var customDateFormatter = this.dateFormatter();
 
-  // Possibly dead code, `d` should always be a string
-  if (customFormatter && d && d instanceof Date) {
+  // Possibly dead code, `key` should always be a string or number
+  if (customDateFormatter && key && key instanceof Date) {
     if (Array.isArray(value) && value[0]) {
       value = value[0].value || value[0];
     }
   }
 
-  // customFormatter is set to autoFormatter (mapd3), which processes raw values
-  // whereas formatDataValue expects an object / array of objects that contain
-  // additional information
+  // For binned data:
+  // customDateFormatter is set to `autoFormatter` (mapd3), which processes raw values in an array
+  // Whereas formatDataValue passes the data to `formatTimeBinValue`, which expects an array
+  // of objects with additional information (like timeBin info)
   var rawValues = Array.isArray(value) ? value.map(function (v) {
     return v.value;
   }) : null;
 
-  return customFormatter && customFormatter(rawValues || value, this.yAxisLabel()) || (0, _formattingHelpers.formatDataValue)(value);
+  return customDateFormatter && customDateFormatter(rawValues || value, this.yAxisLabel()) || (0, _formattingHelpers.formatDataValue)(value);
 }
 
-function heatMapColsLabel(d) {
-  var value = this.colsMap.get(d) || d;
+function heatMapColsLabel(key) {
+  // If the data is binned, this will be an array
+  var value = this.colsMap.get(key) || key;
 
-  // There will only return a value if we're displaying dates
-  var customFormatter = this.dateFormatter();
+  var customDateFormatter = this.dateFormatter();
 
-  // Possibly dead code, `d` should always be a string
-  if (customFormatter && d && d instanceof Date) {
+  // Possibly dead code, `key` should always be a string or number
+  if (customDateFormatter && key && key instanceof Date) {
     if (Array.isArray(value) && value[0]) {
       value = value[0].value || value[0];
     }
   }
 
-  // customFormatter is set to `autoFormatter` (mapd3), which processes raw values.
-  // Whereas formatDataValue expects an object / array of objects that contain
-  // additional information
+  // For binned data:
+  // customDateFormatter is set to `autoFormatter` (mapd3), which processes raw values in an array
+  // Whereas formatDataValue passes the data to `formatTimeBinValue`, which expects an array
+  // of objects with additional information (like timeBin info)
   var rawValues = Array.isArray(value) ? value.map(function (v) {
     return v.value;
   }) : null;
 
-  return customFormatter && customFormatter(rawValues || value, this.xAxisLabel()) || (0, _formattingHelpers.formatDataValue)(value);
+  return customDateFormatter && customDateFormatter(rawValues || value, this.xAxisLabel()) || (0, _formattingHelpers.formatDataValue)(value);
 }
 
 function isDescendingAppropriateData(_ref3) {

--- a/src/charts/heatmap.js
+++ b/src/charts/heatmap.js
@@ -57,52 +57,54 @@ export function heatMapValueAccesor({ key1 }) {
   }
 }
 
-export function heatMapRowsLabel(d) {
-  let value = this.rowsMap.get(d) || d
+export function heatMapRowsLabel(key) {
+  // If the data is binned, this will be an array
+  let value = this.rowsMap.get(key) || key
 
-  // There will only return a value if we're displaying dates
-  const customFormatter = this.dateFormatter()
+  const customDateFormatter = this.dateFormatter()
 
-  // Possibly dead code, `d` should always be a string
-  if (customFormatter && d && d instanceof Date) {
+  // Possibly dead code, `key` should always be a string or number
+  if (customDateFormatter && key && key instanceof Date) {
     if (Array.isArray(value) && value[0]) {
       value = value[0].value || value[0]
     }
   }
 
-  // customFormatter is set to autoFormatter (mapd3), which processes raw values
-  // whereas formatDataValue expects an object / array of objects that contain
-  // additional information
+  // For binned data:
+  // customDateFormatter is set to `autoFormatter` (mapd3), which processes raw values in an array
+  // Whereas formatDataValue passes the data to `formatTimeBinValue`, which expects an array
+  // of objects with additional information (like timeBin info)
   const rawValues = Array.isArray(value) ? value.map(v => v.value) : null
 
   return (
-    (customFormatter &&
-      customFormatter(rawValues || value, this.yAxisLabel())) ||
+    (customDateFormatter &&
+      customDateFormatter(rawValues || value, this.yAxisLabel())) ||
     formatDataValue(value)
   )
 }
 
-export function heatMapColsLabel(d) {
-  let value = this.colsMap.get(d) || d
+export function heatMapColsLabel(key) {
+  // If the data is binned, this will be an array
+  let value = this.colsMap.get(key) || key
 
-  // There will only return a value if we're displaying dates
-  const customFormatter = this.dateFormatter()
+  const customDateFormatter = this.dateFormatter()
 
-  // Possibly dead code, `d` should always be a string
-  if (customFormatter && d && d instanceof Date) {
+  // Possibly dead code, `key` should always be a string or number
+  if (customDateFormatter && key && key instanceof Date) {
     if (Array.isArray(value) && value[0]) {
       value = value[0].value || value[0]
     }
   }
 
-  // customFormatter is set to `autoFormatter` (mapd3), which processes raw values.
-  // Whereas formatDataValue expects an object / array of objects that contain
-  // additional information
+  // For binned data:
+  // customDateFormatter is set to `autoFormatter` (mapd3), which processes raw values in an array
+  // Whereas formatDataValue passes the data to `formatTimeBinValue`, which expects an array
+  // of objects with additional information (like timeBin info)
   const rawValues = Array.isArray(value) ? value.map(v => v.value) : null
 
   return (
-    (customFormatter &&
-      customFormatter(rawValues || value, this.xAxisLabel())) ||
+    (customDateFormatter &&
+      customDateFormatter(rawValues || value, this.xAxisLabel())) ||
     formatDataValue(value)
   )
 }

--- a/src/utils/formatting-helpers.js
+++ b/src/utils/formatting-helpers.js
@@ -104,6 +104,10 @@ export function formatTimeBinValue(data) {
         startTime.value,
         "MMM D, YYYY"
       )} \u205F${momentUTCFormat(startTime.value, "HH:mm")}`
+    case "second":
+      return `${momentUTCFormat(startTime.value, "HH:mm:ss")}`
+    case "millisecond":
+      return `${momentUTCFormat(startTime.value, "HH:mm:ss.SSS")}`
     default:
       return genericDateTimeFormat(startTime.value)
   }


### PR DESCRIPTION
We didn't have formatting options for datasets binned on second or millisecond.

I also updated some comments / variable names in two confusing functions that assign column / row tick labels.