### PR TITLE
[FE-8866] Show modal for BE Scatter when WebGl is not supported

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -45861,6 +45861,9 @@ function coordinateGridRasterMixin(_chart, _mapboxgl, browser) {
     };
     _gl = canvas.getContext("webgl", webglAttrs) || canvas.getContext("experimental-webgl", webglAttrs);
 
+    if (!_gl) {
+      throw { name: "WebGL", message: 'WebGL Not Enabled' };
+    }
     var vertShaderSrc = "" + "precision mediump float;\n" + "attribute vec2 a_pos;\n" + "attribute vec2 a_texCoords;\n" + "\n" + "varying vec2 v_texCoords;\n" + "uniform vec2 u_texCoordsScale;\n" + "uniform vec2 u_texCoordsOffset;\n" + "\n" + "void main(void) {\n" + "    gl_Position = vec4(a_pos, 0, 1);\n" + "\n" + "    v_texCoords = u_texCoordsScale * a_texCoords + u_texCoordsOffset;\n" +
     // NOTE: right now it seems that unpacking the base64 array via the
     // createImageBitmap() call puts pixel 0,0 in the upper left-hand

--- a/src/mixins/coordinate-grid-raster-mixin.js
+++ b/src/mixins/coordinate-grid-raster-mixin.js
@@ -274,6 +274,7 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
     }
     _gl = canvas.getContext("webgl", webglAttrs) || canvas.getContext("experimental-webgl", webglAttrs)
 
+    if(!_gl) { throw {name: "WebGL", message: 'WebGL Not Enabled' }}
     const vertShaderSrc = "" + "precision mediump float;\n" + "attribute vec2 a_pos;\n" + "attribute vec2 a_texCoords;\n" + "\n" + "varying vec2 v_texCoords;\n" + "uniform vec2 u_texCoordsScale;\n" + "uniform vec2 u_texCoordsOffset;\n" + "\n" + "void main(void) {\n" + "    gl_Position = vec4(a_pos, 0, 1);\n" + "\n" + "    v_texCoords = u_texCoordsScale * a_texCoords + u_texCoordsOffset;\n" +
       // NOTE: right now it seems that unpacking the base64 array via the
       // createImageBitmap() call puts pixel 0,0 in the upper left-hand


### PR DESCRIPTION
# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #FE-8866
Relates with: https://github.com/omnisci/mapd-immerse/pull/5608

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
