### PR TITLE
[FE-8836] Fix color legend & bar chart X axis formatting

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -51551,6 +51551,10 @@ function defaultFormatter(value) {
 
 // Finds the name of the color measure, so we can use it when finding the format of the color legend
 function getColorMeasureName(chart) {
+  var groups = chart.group();
+  if (!(groups && groups.reduce)) {
+    return null;
+  }
   var measures = chart.group().reduce();
   if (!Array.isArray(measures)) {
     return null;

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -51549,6 +51549,21 @@ function defaultFormatter(value) {
   return commafy(formattedValue);
 }
 
+// Finds the name of the color measure, so we can use it when finding the format of the color legend
+function getColorMeasureName(chart) {
+  var measures = chart.group().reduce();
+  if (!Array.isArray(measures)) {
+    return null;
+  }
+
+  var colorMeasure = measures.filter(function (x) {
+    return x.name === "color";
+  });
+  // This function should always return either a string or null, never "undefined", since an
+  // "undefined" key to the valueFormatter sends us down a weird code path.
+  return colorMeasure.length > 0 && typeof colorMeasure[0].measureName !== "undefined" ? colorMeasure[0].measureName : null;
+}
+
 function legendMixin(chart) {
   chart.legendablesContinuous = function () {
     var legends = [];
@@ -51557,6 +51572,7 @@ function legendMixin(chart) {
     var colorDomainSize = colorDomain[1] - colorDomain[0];
     var colorRange = chart.colors().range();
     var numColors = colorRange.length;
+    var colorMeasureName = getColorMeasureName(chart);
 
     for (var c = 0; c < numColors; c++) {
       var startRange = c / numColors * colorDomainSize + colorDomain[0];
@@ -51579,7 +51595,7 @@ function legendMixin(chart) {
       var valueFormatter = chart.valueFormatter();
       var value = startRange;
       if (!isNaN(value)) {
-        value = valueFormatter && valueFormatter(value) || defaultFormatter(value);
+        value = valueFormatter && valueFormatter(value, colorMeasureName) || defaultFormatter(value);
       }
 
       legends.push({
@@ -72833,8 +72849,12 @@ function rowChart(parent, chartGroup) {
 
   function setXAxisFormat() {
     var numberFormatter = _chart.valueFormatter();
-    if (numberFormatter) {
-      var key = _chart.getMeasureName();
+    var key = _chart.getMeasureName();
+    // We have no good way of knowing if the valueFormatter has a formatter for the X axis in
+    // particular, since that code is a black box. So we run through a test value and if it returns
+    // `null`, we know it doesn't know how to format it. It's dumb, but it works.
+    var validFormatting = numberFormatter && numberFormatter(0, key) !== null;
+    if (validFormatting) {
       xFormatCache.setTickFormat(function (d) {
         return numberFormatter(d, key);
       });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4920,7 +4920,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4941,12 +4942,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4961,17 +4964,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5088,7 +5094,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5100,6 +5107,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5114,6 +5122,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5121,12 +5130,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5145,6 +5156,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5232,7 +5244,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5244,6 +5257,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5329,7 +5343,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5365,6 +5380,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5384,6 +5400,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5427,12 +5444,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8825,6 +8844,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9574,7 +9594,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/src/charts/row-chart.js
+++ b/src/charts/row-chart.js
@@ -131,8 +131,12 @@ export default function rowChart(parent, chartGroup) {
 
   function setXAxisFormat () {
     const numberFormatter = _chart.valueFormatter()
-    if (numberFormatter) {
-      const key = _chart.getMeasureName()
+    const key = _chart.getMeasureName()
+    // We have no good way of knowing if the valueFormatter has a formatter for the X axis in
+    // particular, since that code is a black box. So we run through a test value and if it returns
+    // `null`, we know it doesn't know how to format it. It's dumb, but it works.
+    const validFormatting = numberFormatter && numberFormatter(0, key) !== null
+    if (validFormatting) {
       xFormatCache.setTickFormat(d => numberFormatter(d, key))
     } else {
       xFormatCache.setTickFormatFromCache()

--- a/src/charts/row-chart.js
+++ b/src/charts/row-chart.js
@@ -129,7 +129,7 @@ export default function rowChart(parent, chartGroup) {
     _chart.xAxis().ticks(_chart.getNumTicksForXAxis())
   }
 
-  function setXAxisFormat () {
+  function setXAxisFormat() {
     const numberFormatter = _chart.valueFormatter()
     const key = _chart.getMeasureName()
     // We have no good way of knowing if the valueFormatter has a formatter for the X axis in
@@ -234,7 +234,10 @@ export default function rowChart(parent, chartGroup) {
     const key = _chart.getMeasureName()
     const customFormatter = _chart.valueFormatter()
     const value = _chart.cappedValueAccessor(d)
-    return customFormatter && customFormatter(value, key) || utils.formatValue(value)
+    return (
+      (customFormatter && customFormatter(value, key)) ||
+      utils.formatValue(value)
+    )
   }
   /* ------------------------------------------------------------------------- */
 
@@ -258,13 +261,11 @@ export default function rowChart(parent, chartGroup) {
   }
 
   function drawGridLines() {
-    _g
-      .selectAll("g.tick")
+    _g.selectAll("g.tick")
       .select("line.grid-line")
       .remove()
 
-    _g
-      .selectAll("g.tick")
+    _g.selectAll("g.tick")
       .append("line")
       .attr("class", "grid-line")
       .attr("x1", 0)
@@ -369,9 +370,8 @@ export default function rowChart(parent, chartGroup) {
       .attr("height", height)
       .attr("fill", _chart.getColor)
       .on("click", onClick)
-      .classed(
-        "deselected",
-        d => (_chart.hasFilter() ? !isSelectedRow(d) : false)
+      .classed("deselected", d =>
+        _chart.hasFilter() ? !isSelectedRow(d) : false
       )
       .classed("selected", d => (_chart.hasFilter() ? isSelectedRow(d) : false))
 

--- a/src/mixins/legend-mixin.js
+++ b/src/mixins/legend-mixin.js
@@ -16,6 +16,10 @@ function defaultFormatter(value) {
 
 // Finds the name of the color measure, so we can use it when finding the format of the color legend
 function getColorMeasureName(chart) {
+  const groups = chart.group()
+  if (!(groups && groups.reduce)) {
+    return null
+  }
   const measures = chart.group().reduce()
   if (!Array.isArray(measures)) {
     return null

--- a/src/mixins/legend-mixin.js
+++ b/src/mixins/legend-mixin.js
@@ -4,7 +4,7 @@ import { override } from "../../src/core/core"
 const PERCENTAGE = 100.0
 const LOWER_THAN_START_RANGE = 1000
 
-function defaultFormatter (value) {
+function defaultFormatter(value) {
   const commafy = d3.format(",")
   let formattedValue = parseFloat(value).toFixed(2)
   if (value >= LOWER_THAN_START_RANGE) {
@@ -41,7 +41,7 @@ export default function legendMixin(chart) {
     const colorMeasureName = getColorMeasureName(chart)
 
     for (let c = 0; c < numColors; c++) {
-      let startRange = c / numColors * colorDomainSize + colorDomain[0]
+      let startRange = (c / numColors) * colorDomainSize + colorDomain[0]
       if (chart.isTargeting()) {
         startRange = "%" + (parseFloat(startRange) * PERCENTAGE).toFixed(2)
       } else if (chart.colorByExpr() === "count(*)") {


### PR DESCRIPTION
# Summary
### Fix formatting of color dimension

There was a, uh, bug?, where the color legend wasn't passing the color measure name to mapd3's `autoFormatter`. This meant that mapd3 wouldn't be able to associate the color legend values with a specific format string, and would default to the first format string found (for reasons). This commit changes it so that the color legend looks up the color measure name before formatting the legend values.

### Fix formatting of X axis values in row chart

There was a bug where the X axis would only check that _some_ value formatter had been set before trying to format the X axis values, but it didn't check that the formatter had any specific formatter for the X axis. Because mapd3 will default to the first format string found if it doesn't know how to format a specific measure, this caused weirdness when the user set a color format but not a regular measure format.

This commit changes that behavior so that we check the value formatter to ensure it knows how to format the X axis values. Because the value formatter is a block box, we can't test this directly. Instead, we run through a test value (`0.0`) and see if it returns a value value.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Fixes FE-8836

## :smoking: Smoke Test
- [x] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
