### PR TITLE
[FE-8908] Bump crossfilter to fix nulls last queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
       }
     },
     "@mapd/crossfilter": {
-      "version": "github:omnisci/mapd-crossfilter#99f4cf4f5e7db7fa4427c5294da692b3d7717ecf",
-      "from": "github:omnisci/mapd-crossfilter#99f4cf4f5e7db7fa4427c5294da692b3d7717ecf",
+      "version": "github:omnisci/mapd-crossfilter#2a44363acd4daa54cbdc267ca68f5ac816714745",
+      "from": "github:omnisci/mapd-crossfilter#2a44363acd4daa54cbdc267ca68f5ac816714745",
       "dev": true
     },
     "@mapd/mapd-draw": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4920,7 +4920,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4941,12 +4942,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4961,17 +4964,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5088,7 +5094,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5100,6 +5107,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5114,6 +5122,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5121,12 +5130,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5145,6 +5156,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5232,7 +5244,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5244,6 +5257,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5329,7 +5343,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5365,6 +5380,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5384,6 +5400,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5427,12 +5444,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8825,6 +8844,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9574,7 +9594,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,8 @@
       }
     },
     "@mapd/crossfilter": {
-      "version": "github:omnisci/mapd-crossfilter#2a44363acd4daa54cbdc267ca68f5ac816714745",
-      "from": "github:omnisci/mapd-crossfilter#2a44363acd4daa54cbdc267ca68f5ac816714745",
+      "version": "github:omnisci/mapd-crossfilter#06a064d1dad5a9f75cbfff3664b196da9f5ddf6b",
+      "from": "github:omnisci/mapd-crossfilter#06a064d",
       "dev": true
     },
     "@mapd/mapd-draw": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@mapd/connector": "omnisci/mapd-connector#d75148077a2a4b23d66d89c63d05c20e5735af2e",
-    "@mapd/crossfilter": "omnisci/mapd-crossfilter#2a44363acd4daa54cbdc267ca68f5ac816714745",
+    "@mapd/crossfilter": "omnisci/mapd-crossfilter#06a064d",
     "atob": "^2.0.3",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@mapd/connector": "omnisci/mapd-connector#d75148077a2a4b23d66d89c63d05c20e5735af2e",
-    "@mapd/crossfilter": "omnisci/mapd-crossfilter#99f4cf4f5e7db7fa4427c5294da692b3d7717ecf",
+    "@mapd/crossfilter": "omnisci/mapd-crossfilter#2a44363acd4daa54cbdc267ca68f5ac816714745",
     "atob": "^2.0.3",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",


### PR DESCRIPTION
This bumps the version of crossfilter used here to pull in a fix for `NULLS LAST` in queries. See omnisci/mapd-crossfilter#88 for more info.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Fixes FE-8908

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
