### PR TITLE
[FE-8934] Fix hpt binning with colors in histogram

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -6081,7 +6081,10 @@ function baseMixin(_chart) {
   var _renderLabel = false;
 
   var _title = function _title(d) {
-    return _chart.keyAccessor()(d) + ": " + _chart.valueAccessor()(d);
+    var key = _chart.keyAccessor()(d);
+    var value = _chart.valueAccessor()(d);
+    // return _chart.keyAccessor()(d) + ": " + _chart.valueAccessor()(d)
+    return (key instanceof Date ? key.toISOString() : key) + ": " + (value instanceof Date ? value.toISOString() : value);
   };
   var _renderTitle = true;
   var _controlsUseVisibility = true;
@@ -9123,7 +9126,9 @@ function coordinateGridMixin(_chart) {
 
   function compareDomains(d1, d2) {
     return !d1 || !d2 || d1.length !== d2.length || d1.some(function (elem, i) {
-      return elem && d2[i] ? elem.toString() !== d2[i].toString() : elem === d2[i];
+      var elemString = elem instanceof Date ? elem.toISOString() : elem.toString();
+      var d2String = d2[i] instanceof Date ? d2[i].toISOString() : d2[i].toString();
+      return elem && d2[i] ? elemString !== d2String : elem === d2[i];
     });
   }
 
@@ -44584,8 +44589,9 @@ function processMultiSeriesResults(results) {
     if (Array.isArray(key0)) {
       var isExtract = key0[0].isExtract;
 
-      var min = isExtract ? key0[0].value : key0[0].value || key0[0];
-      var alias = key0[0].alias || min;
+      var rawMin = isExtract ? key0[0].value : key0[0].value || key0[0];
+      var min = rawMin instanceof Date ? rawMin.toISOString() : rawMin;
+      var alias = key0[0].alias instanceof Date ? key0[0].alias.toISOString() : key0[0].alias || min;
 
       if (typeof accum.ranges[alias] !== "number") {
         // eslint-disable-line no-negated-condition

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -6083,7 +6083,6 @@ function baseMixin(_chart) {
   var _title = function _title(d) {
     var key = _chart.keyAccessor()(d);
     var value = _chart.valueAccessor()(d);
-    // return _chart.keyAccessor()(d) + ": " + _chart.valueAccessor()(d)
     return (key instanceof Date ? key.toISOString() : key) + ": " + (value instanceof Date ? value.toISOString() : value);
   };
   var _renderTitle = true;

--- a/src/mixins/base-mixin.js
+++ b/src/mixins/base-mixin.js
@@ -95,7 +95,6 @@ export default function baseMixin(_chart) {
   let _title = function(d) {
     const key = _chart.keyAccessor()(d)
     const value = _chart.valueAccessor()(d)
-    // return _chart.keyAccessor()(d) + ": " + _chart.valueAccessor()(d)
     return `${key instanceof Date ? key.toISOString() : key}: ${
       value instanceof Date ? value.toISOString() : value
     }`

--- a/src/mixins/base-mixin.js
+++ b/src/mixins/base-mixin.js
@@ -93,7 +93,12 @@ export default function baseMixin(_chart) {
   let _renderLabel = false
 
   let _title = function(d) {
-    return _chart.keyAccessor()(d) + ": " + _chart.valueAccessor()(d)
+    const key = _chart.keyAccessor()(d)
+    const value = _chart.valueAccessor()(d)
+    // return _chart.keyAccessor()(d) + ": " + _chart.valueAccessor()(d)
+    return `${key instanceof Date ? key.toISOString() : key}: ${
+      value instanceof Date ? value.toISOString() : value
+    }`
   }
   let _renderTitle = true
   let _controlsUseVisibility = true

--- a/src/mixins/coordinate-grid-mixin.js
+++ b/src/mixins/coordinate-grid-mixin.js
@@ -503,8 +503,11 @@ export default function coordinateGridMixin (_chart) {
   function compareDomains (d1, d2) {
     return (
       !d1 || !d2 || d1.length !== d2.length || d1.some(
-        (elem, i) =>
-          elem && d2[i] ? elem.toString() !== d2[i].toString() : elem === d2[i]
+        (elem, i) => {
+          const elemString = elem instanceof Date ? elem.toISOString() : elem.toString()
+          const d2String = d2[i] instanceof Date ? d2[i].toISOString() : d2[i].toString()
+          return elem && d2[i] ? elemString !== d2String : elem === d2[i]
+        }
       )
     )
   }

--- a/src/mixins/multi-series-mixin.js
+++ b/src/mixins/multi-series-mixin.js
@@ -18,8 +18,12 @@ function processMultiSeriesResults(results) {
 
       if (Array.isArray(key0)) {
         const { isExtract } = key0[0]
-        const min = isExtract ? key0[0].value : key0[0].value || key0[0]
-        const alias = key0[0].alias || min
+        const rawMin = isExtract ? key0[0].value : key0[0].value || key0[0]
+        const min = rawMin instanceof Date ? rawMin.toISOString() : rawMin
+        const alias =
+          key0[0].alias instanceof Date
+            ? key0[0].alias.toISOString()
+            : key0[0].alias || min
 
         if (typeof accum.ranges[alias] !== "number") {
           // eslint-disable-line no-negated-condition


### PR DESCRIPTION
Use millisecond resolution for Dates in multi-series-mixin

In the `processMultiSeriesResults()` function in `multi-series-mixin.js`, add a check to see if the values be used are Date objects. If so, explicitly call `toISOString()` instead of letting it implicitly call `toString()`, so that we retain millisecond precision.

This change should fix using HPT values on histogram with a color dimension. Previously, you would only get one bin, since `toString()` cuts off milliseconds. Now, we get the proper binning.

This PR also fixes two other functions, `_title()` and `compareDomains()` to be HPT-aware. These weren't directly related to the bug in question, but were incidentally discovered in the course of fixing this bug.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Fixes FE-8934

## :smoking: Smoke Test
- [x] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
