### PR TITLE
[FE-8955] Format codebase + add formatting checker to test suite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4919,7 +4919,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4940,12 +4941,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4960,17 +4963,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5087,7 +5093,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5099,6 +5106,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5113,6 +5121,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5120,12 +5129,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5144,6 +5155,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5231,7 +5243,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5243,6 +5256,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5328,7 +5342,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5364,6 +5379,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5383,6 +5399,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5426,12 +5443,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8824,6 +8843,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9573,7 +9593,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "docs": "npm run build:docs && open docs/index.html",
     "format": "prettier --write '{src,test}/**/*.js'",
     "format:check": "prettier --debug-check --list-different '{src,test}/**/*.js'",
+    "format:check:silent": "./scripts/check-formatting.sh",
     "format:lint": "npm run format && npm run lint:fix",
     "format:check:lint": "npm run format:check && npm run lint",
     "lint": "./node_modules/.bin/eslint $(find src -name \"*.js\" ! -name '*.spec.js')",
@@ -48,7 +49,7 @@
     "selenium:install": "selenium-standalone install --version=3.0.0-beta4",
     "selenium:start": "selenium-standalone start --version=3.0.0-beta4",
     "start": "webpack-dev-server --content-base ./example --config ./example/webpack.config.js",
-    "test": "npm run lint && npm run test:unit",
+    "test": "npm run format:check:silent && npm run lint && npm run test:unit",
     "test:unit": "find ./src -name '*.spec.js' | BABEL_ENV=test NODE_PATH=./src xargs nyc mocha --opts ./test/mocha.unit.opts"
   },
   "dependencies": {

--- a/scripts/check-formatting.sh
+++ b/scripts/check-formatting.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# This script basically just runs `prettier`, but it adds a header and footer so that people aren't
+# confused why their CI builds failed, since prettier's output is less-than-helpful.
+
+echo -e "=====> Checking code formatting\n"
+
+prettier --list-different '{src,test}/**/*.js'
+
+PRETTIER_RES=$?
+
+if [[ $PRETTIER_RES -ne 0 ]]; then
+    echo -e "\n!!! FATAL ERROR: The above files have formatting problems. Run \`npm run format\` to fix.\n\n"
+else
+    echo -e "---> No code formatting problems found\n\n"
+fi
+
+exit $PRETTIER_RES

--- a/src/chart-addons/dc-legend-cont.js
+++ b/src/chart-addons/dc-legend-cont.js
@@ -121,9 +121,8 @@ export default function legendCont() {
       .append("div")
       .attr("class", "legend-input")
       .append("input")
-      .attr(
-        "value",
-        d => (typeof d === "object" && d.value !== "NaN" ? d.value : 0)
+      .attr("value", d =>
+        typeof d === "object" && d.value !== "NaN" ? d.value : 0
       ) // eslint-disable-line no-confusing-arrow
       .on("click", function() {
         this.select()

--- a/src/chart-addons/legend.js
+++ b/src/chart-addons/legend.js
@@ -63,9 +63,9 @@ export default function legend() {
         d.chart.legendToggle(d)
       })
 
-    _g
-      .selectAll("g.dc-legend-item")
-      .classed("fadeout", d => d.chart.isLegendableHidden(d))
+    _g.selectAll("g.dc-legend-item").classed("fadeout", d =>
+      d.chart.isLegendableHidden(d)
+    )
 
     if (legendables.some(pluck("dashstyle"))) {
       itemEnter

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -10,8 +10,15 @@ const handleColorLegendOpenUndefined = color =>
   typeof color.legend.open === "undefined" ? true : color.legend.open
 const handleNonStackedOpenState = state =>
   state.type === "gradient" ? Object.assign({}, state, { open: true }) : state
-const handleNonStackedNullLegend = state => // used for ["NULL", "NULL"} quantitative legend domain
-  Object.assign({}, state, { type: 'nominal', range: state.range, domain: state.domain.slice(1), open: true })
+const handleNonStackedNullLegend = (
+  state // used for ["NULL", "NULL"} quantitative legend domain
+) =>
+  Object.assign({}, state, {
+    type: "nominal",
+    range: state.range,
+    domain: state.domain.slice(1),
+    open: true
+  })
 
 const TOP_PADDING = 56
 const LASSO_TOOL_VERTICAL_SPACE = 120
@@ -83,7 +90,6 @@ function setColorScaleDomain_v1(domain) {
 }
 
 export function getLegendStateFromChart(chart, useMap, selectedLayer) {
-
   // the getLegendStateFromChart in _doRender gets called from few different options
   // and some of them are calling with all layers in chart.
   // As a result, a legend for each layer is rendered.
@@ -91,8 +97,14 @@ export function getLegendStateFromChart(chart, useMap, selectedLayer) {
   const legends = chart.root().selectAll(".legend")
   const layers = chart.getLayerNames()
 
-  if(legends.size() > layers.length && selectedLayer && selectedLayer.currentLayer !== "master") {
-    chart.root().selectAll(".legend")
+  if (
+    legends.size() > layers.length &&
+    selectedLayer &&
+    selectedLayer.currentLayer !== "master"
+  ) {
+    chart
+      .root()
+      .selectAll(".legend")
       .filter((d, i) => i !== selectedLayer.currentLayer)
       .remove()
   }
@@ -103,7 +115,7 @@ export function getLegendStateFromChart(chart, useMap, selectedLayer) {
       const layerState = layer.getState()
       const color = layer.getState().encoding.color
 
-      if(layers.length > 1 || _.isEqual(selectedLayer, layerState)) {
+      if (layers.length > 1 || _.isEqual(selectedLayer, layerState)) {
         if (typeof color.scale === "object" && color.scale.domain === "auto") {
           return {
             ...color,
@@ -184,7 +196,9 @@ export function handleLegendLock({ locked, index = 0 }) {
     }))
   )
 
-  const { encoding: { color } } = layer.getState()
+  const {
+    encoding: { color }
+  } = layer.getState()
   let redraw = false
   if (typeof color.scale === "object") {
     // this if or raster-layer-heatmap-mixin.js
@@ -218,7 +232,8 @@ export function handleLegendInput({ domain, index = 0 }) {
   const layer = this.getLayers()[index]
   const { scale } = layer.getState().encoding.color
 
-  const legendDomain = this.legend().state.domain || this.legend().state.list[index].domain
+  const legendDomain =
+    this.legend().state.domain || this.legend().state.list[index].domain
   if (_.difference(domain, legendDomain).length > 0) {
     // automatically lock color legend when min/max input changes
     layer.setState(
@@ -252,7 +267,12 @@ function legendState(state, useMap = true) {
       domain: state.domain,
       position: useMap ? "bottom-left" : "top-right"
     }
-  } else if(state.type === "quantitative" && state.domain && isNullLegend(state.domain)) { // handles quantitative legend for all null color measure column, ["NULL", "NULL"] domain
+  } else if (
+    state.type === "quantitative" &&
+    state.domain &&
+    isNullLegend(state.domain)
+  ) {
+    // handles quantitative legend for all null color measure column, ["NULL", "NULL"] domain
     return {
       type: "nominal", // show nominal legend with one "NULL" value when all null quantitavie color measure is selected
       title: hasLegendTitleProp(state) ? state.legend.title : "Legend",
@@ -288,10 +308,14 @@ function legendState(state, useMap = true) {
 }
 
 export function toLegendState(states = [], chart, useMap) {
-  if(states.length === 1 && states[0].domain && isNullLegend(states[0].domain)) { // handles legend for all null color measure column, ["NULL", "NULL"] domain
+  if (
+    states.length === 1 &&
+    states[0].domain &&
+    isNullLegend(states[0].domain)
+  ) {
+    // handles legend for all null color measure column, ["NULL", "NULL"] domain
     return handleNonStackedNullLegend(states[0], useMap)
-  } else
-    if (states.length === 1) {
+  } else if (states.length === 1) {
     return handleNonStackedOpenState(legendState(states[0], useMap))
   } else if (states.length) {
     return {

--- a/src/charts/bar-chart.js
+++ b/src/charts/bar-chart.js
@@ -83,7 +83,9 @@ export default function barChart(parent, chartGroup) {
 
   _chart.measureValue = function(value) {
     const customFormatter = _chart.valueFormatter()
-    return customFormatter && customFormatter(value) || utils.formatValue(value)
+    return (
+      (customFormatter && customFormatter(value)) || utils.formatValue(value)
+    )
   }
 
   _chart.plotData = function() {
@@ -308,7 +310,9 @@ export default function barChart(parent, chartGroup) {
       }
     }
 
-    const bars = layer.selectAll("rect.bar").data(d.values, (d) => (d.x instanceof Date) ? d.x.getTime() : d.x)
+    const bars = layer
+      .selectAll("rect.bar")
+      .data(d.values, d => (d.x instanceof Date ? d.x.getTime() : d.x))
 
     const enter = bars
       .enter()

--- a/src/charts/box-plot.js
+++ b/src/charts/box-plot.js
@@ -189,8 +189,7 @@ export default function boxPlot(parent, chartGroup) {
       .attr("transform", boxTransform)
       .call(_box)
       .each(function() {
-        d3
-          .select(this)
+        d3.select(this)
           .select("rect.box")
           .attr("fill", _chart.getColor)
       })

--- a/src/charts/bubble-chart.js
+++ b/src/charts/bubble-chart.js
@@ -59,7 +59,10 @@ export default function bubbleChart(parent, chartGroup) {
   _chart.measureValue = function(value, key, type) {
     if (type === "measure") {
       const customFormatter = _chart.valueFormatter()
-      return customFormatter && customFormatter(value, key) || utils.formatValue(value)
+      return (
+        (customFormatter && customFormatter(value, key)) ||
+        utils.formatValue(value)
+      )
     } else {
       utils.formatValue(value)
     }
@@ -106,11 +109,11 @@ export default function bubbleChart(parent, chartGroup) {
             continue
           }
 
-          const aXmin = aX - String(aKey).length * letterWidth / 2
-          const aXmax = aX + String(aKey).length * letterWidth / 2
+          const aXmin = aX - (String(aKey).length * letterWidth) / 2
+          const aXmax = aX + (String(aKey).length * letterWidth) / 2
 
-          const bXmin = bX - String(bKey).length * letterWidth / 2
-          const bXmax = bX + String(bKey).length * letterWidth / 2
+          const bXmin = bX - (String(bKey).length * letterWidth) / 2
+          const bXmax = bX + (String(bKey).length * letterWidth) / 2
 
           const isLabelOverlapped =
             (aXmin >= bXmin && aXmin <= bXmax) ||
@@ -225,8 +228,7 @@ export default function bubbleChart(parent, chartGroup) {
         })
       })
       .on("mouseleave", function() {
-        d3
-          .select(this)
+        d3.select(this)
           .classed("scroll-text", false)
           .style("transform", "translateX(0)")
       })
@@ -281,8 +283,7 @@ export default function bubbleChart(parent, chartGroup) {
         .popup()
         .selectAll(".popup-row-item")
         .each(function(d) {
-          d3
-            .select(this)
+          d3.select(this)
             .classed("deselected", !_chart.isSelectedNode(d))
             .classed("selected", _chart.isSelectedNode(d))
         })
@@ -310,7 +311,11 @@ export default function bubbleChart(parent, chartGroup) {
     for (let i = 1; i < _popupHeader.length; i++) {
       if (_popupHeader[i].alias) {
         const value = _popupHeader[i]
-        str = str + ("<td>" + _chart.measureValue(d[value.alias], value.label, value.type) + "</td>")
+        str =
+          str +
+          ("<td>" +
+            _chart.measureValue(d[value.alias], value.label, value.type) +
+            "</td>")
       }
     }
     return str
@@ -341,15 +346,13 @@ export default function bubbleChart(parent, chartGroup) {
         x - popupWidth < 0
           ? popupWidth - x - 16
           : x + popupWidth > _chart.width()
-            ? _chart.width() - (x + popupWidth) + 16
-            : 0
+          ? _chart.width() - (x + popupWidth) + 16
+          : 0
 
-      d3
-        .select(this)
+      d3.select(this)
         .select(".popup-bridge")
-        .style(
-          "left",
-          () => (offsetX !== 0 ? popupWidth - offsetX + "px" : "50%")
+        .style("left", () =>
+          offsetX !== 0 ? popupWidth - offsetX + "px" : "50%"
         )
       return "translate(" + (x + offsetX) + "px," + y + "px)"
     })
@@ -367,15 +370,13 @@ export default function bubbleChart(parent, chartGroup) {
         )
       })
       .select(".popup-table-wrap")
-      .style(
-        "overflow-y",
-        () =>
-          popup
-            .select(".popup-table")
-            .node()
-            .getBoundingClientRect().height > 160
-            ? "scroll"
-            : "hidden"
+      .style("overflow-y", () =>
+        popup
+          .select(".popup-table")
+          .node()
+          .getBoundingClientRect().height > 160
+          ? "scroll"
+          : "hidden"
       )
   }
 

--- a/src/charts/bubble-overlay.js
+++ b/src/charts/bubble-overlay.js
@@ -141,9 +141,9 @@ export default function bubbleOverlay(parent, chartGroup) {
       return
     }
     const xPixelScale =
-      1.0 / (_chart.bounds[1][0] - _chart.bounds[0][0]) * _chart.width()
+      (1.0 / (_chart.bounds[1][0] - _chart.bounds[0][0])) * _chart.width()
     const yPixelScale =
-      1.0 / (_chart.bounds[1][1] - _chart.bounds[0][1]) * _chart.height()
+      (1.0 / (_chart.bounds[1][1] - _chart.bounds[0][1])) * _chart.height()
     const mapCoords = conv4326To900913([d.x, d.y])
     const pixelPos = {
       x: (mapCoords[0] - _chart.bounds[0][0]) * xPixelScale,
@@ -224,9 +224,9 @@ export default function bubbleOverlay(parent, chartGroup) {
       return
     }
     const xPixelScale =
-      1.0 / (_chart.bounds[1][0] - _chart.bounds[0][0]) * _chart.width()
+      (1.0 / (_chart.bounds[1][0] - _chart.bounds[0][0])) * _chart.width()
     const yPixelScale =
-      1.0 / (_chart.bounds[1][1] - _chart.bounds[0][1]) * _chart.height()
+      (1.0 / (_chart.bounds[1][1] - _chart.bounds[0][1])) * _chart.height()
     const numPoints = data.length
     for (let i = 0; i < numPoints; i++) {
       const coordTrans = conv4326To900913([data[i].x, data[i].y])
@@ -245,9 +245,9 @@ export default function bubbleOverlay(parent, chartGroup) {
       return
     }
     const xPixelScale =
-      1.0 / (_chart.bounds[1][0] - _chart.bounds[0][0]) * _chart.width()
+      (1.0 / (_chart.bounds[1][0] - _chart.bounds[0][0])) * _chart.width()
     const yPixelScale =
-      1.0 / (_chart.bounds[1][1] - _chart.bounds[0][1]) * _chart.height()
+      (1.0 / (_chart.bounds[1][1] - _chart.bounds[0][1])) * _chart.height()
     const numPoints = _chart.savedData.length
     for (let p = 0; p < numPoints; p++) {
       _chart.savedData[p].xPixel =
@@ -282,24 +282,16 @@ export default function bubbleOverlay(parent, chartGroup) {
       .attr("transform", d => "translate(" + d.xPixel + "," + d.yPixel + ")")
       .append("circle")
       .attr("class", _chart.BUBBLE_CLASS)
-      .attr(
-        "r",
-        d =>
-          _chart.scaleRadius
-            ? _chart.bubbleR(d)
-            : _chart.radiusValueAccessor()(d)
+      .attr("r", d =>
+        _chart.scaleRadius ? _chart.bubbleR(d) : _chart.radiusValueAccessor()(d)
       )
       .attr("fill", _chart.getColor)
       .on("click", _chart.onClick)
 
     bubbleG
       .attr("transform", d => "translate(" + d.xPixel + "," + d.yPixel + ")")
-      .attr(
-        "r",
-        d =>
-          _chart.scaleRadius
-            ? _chart.bubbleR(d)
-            : _chart.radiusValueAccessor()(d)
+      .attr("r", d =>
+        _chart.scaleRadius ? _chart.bubbleR(d) : _chart.radiusValueAccessor()(d)
       )
 
     bubbleG.exit().remove()

--- a/src/charts/cloud-chart.js
+++ b/src/charts/cloud-chart.js
@@ -86,9 +86,8 @@ export default function cloudChart(parent, chartGroup) {
       )
       .text(d => d.key0)
       .on("click", onClick)
-      .classed(
-        "deselected",
-        d => (_chart.hasFilter() ? !isSelectedTag(d) : false)
+      .classed("deselected", d =>
+        _chart.hasFilter() ? !isSelectedTag(d) : false
       )
       .classed("selected", d => (_chart.hasFilter() ? isSelectedTag(d) : false))
 

--- a/src/charts/geo-choropleth-chart.js
+++ b/src/charts/geo-choropleth-chart.js
@@ -85,7 +85,8 @@ export default function geoChoroplethChart(parent, useMap, chartGroup, mapbox) {
     this.map().remove()
   }
 
-  _chart.getClosestResult = function() { // don't use logic in mouseup event in map-mixin.js
+  _chart.getClosestResult = function() {
+    // don't use logic in mouseup event in map-mixin.js
     return
   }
 

--- a/src/charts/line-chart.js
+++ b/src/charts/line-chart.js
@@ -170,12 +170,16 @@ export default function lineChart(parent, chartGroup) {
 
   _chart.measureValue = function(value) {
     const customFormatter = _chart.valueFormatter()
-    return (customFormatter && customFormatter(value)) || utils.formatValue(value)
+    return (
+      (customFormatter && customFormatter(value)) || utils.formatValue(value)
+    )
   }
 
   _chart.dimensionValue = function(value) {
     const customFormatter = _chart.dateFormatter()
-    return (customFormatter && customFormatter(value)) || utils.formatValue(value)
+    return (
+      (customFormatter && customFormatter(value)) || utils.formatValue(value)
+    )
   }
   /**
    * Get or set render area flag. If the flag is set to true then the chart will render the area
@@ -362,11 +366,10 @@ export default function lineChart(parent, chartGroup) {
     const popupItems = popupBox
       .selectAll(".popup-item")
       .data(
-        arr.sort(
-          (a, b) =>
-            _renderArea
-              ? b.datum.y + b.datum.y0 - (a.datum.y + a.datum.y0)
-              : b.datum.y - a.datum.y
+        arr.sort((a, b) =>
+          _renderArea
+            ? b.datum.y + b.datum.y0 - (a.datum.y + a.datum.y0)
+            : b.datum.y - a.datum.y
         )
       )
       .enter()
@@ -521,12 +524,10 @@ export default function lineChart(parent, chartGroup) {
     const yAxisRefPathD = "M" + yAxisX + " " + y + "L" + x + " " + y
     const xAxisRefPathD =
       "M" + x + " " + _chart.yAxisHeight() + "L" + x + " " + y
-    g
-      .select("path." + Y_AXIS_REF_LINE_CLASS)
+    g.select("path." + Y_AXIS_REF_LINE_CLASS)
       .style("display", "")
       .attr("d", yAxisRefPathD)
-    g
-      .select("path." + X_AXIS_REF_LINE_CLASS)
+    g.select("path." + X_AXIS_REF_LINE_CLASS)
       .style("display", "")
       .attr("d", xAxisRefPathD)
   }

--- a/src/charts/number-chart.js
+++ b/src/charts/number-chart.js
@@ -73,9 +73,13 @@ export default function numberChart(parent, chartGroup) {
     const TEXT_PADDING_RATIO = 5
     const chartWidth = _chart.width()
     const chartHeight = _chart.height()
-    const wrapperWidth = chartWidth - chartWidth / 100 * TEXT_PADDING_RATIO
-    const wrapperHeight = chartHeight - chartHeight / 100 * TEXT_PADDING_RATIO
-    const fontSize = utils.getFontSizeFromWidth(formattedValue, wrapperWidth, wrapperHeight)
+    const wrapperWidth = chartWidth - (chartWidth / 100) * TEXT_PADDING_RATIO
+    const wrapperHeight = chartHeight - (chartHeight / 100) * TEXT_PADDING_RATIO
+    const fontSize = utils.getFontSizeFromWidth(
+      formattedValue,
+      wrapperWidth,
+      wrapperHeight
+    )
     wrapper
       .append("span")
       .attr("class", "number-chart-number")

--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -87,7 +87,10 @@ export default function pieChart(parent, chartGroup) {
     const key = _chart.getMeasureName()
     const customFormatter = _chart.valueFormatter()
     const value = _chart.cappedValueAccessor(d)
-    return customFormatter && customFormatter(value, key) || utils.formatValue(value)
+    return (
+      (customFormatter && customFormatter(value, key)) ||
+      utils.formatValue(value)
+    )
   }
 
   _chart.redoSelect = highlightFilter
@@ -211,7 +214,7 @@ export default function pieChart(parent, chartGroup) {
         "deselected-label",
         d => _chart.hasFilter() && !isSelectedSlice(d)
       )
-      .html((d) => _chart.label()(d.data))
+      .html(d => _chart.label()(d.data))
       .html(function(d) {
         const availableLabelWidth = getAvailableLabelWidth(d)
         const width = d3
@@ -248,7 +251,7 @@ export default function pieChart(parent, chartGroup) {
         .text(function(d) {
           if (d3.select(this.parentNode).classed("hide-label")) {
             return ""
-          } 
+          }
           const availableLabelWidth = getAvailableLabelWidth(d)
           const width = d3
             .select(this)
@@ -334,9 +337,8 @@ export default function pieChart(parent, chartGroup) {
           return [arc.centroid(d2), arc2.centroid(d2)]
         }
       })
-      .style(
-        "visibility",
-        d => (d.endAngle - d.startAngle < 0.0001 ? "hidden" : "visible")
+      .style("visibility", d =>
+        d.endAngle - d.startAngle < 0.0001 ? "hidden" : "visible"
       )
   }
 
@@ -373,8 +375,7 @@ export default function pieChart(parent, chartGroup) {
 
   function updateTitles(pieData) {
     if (_chart.renderTitle()) {
-      _g
-        .selectAll("g." + _sliceCssClass)
+      _g.selectAll("g." + _sliceCssClass)
         .data(pieData)
         .select("title")
         .text(d => _chart.title()(d.data))
@@ -616,7 +617,9 @@ export default function pieChart(parent, chartGroup) {
   function truncateLabel(data, width, availableLabelWidth) {
     if (width > availableLabelWidth) {
       const APPROX_FONT_WIDTH = 9
-      return String(data).slice(0, availableLabelWidth / APPROX_FONT_WIDTH) + "…"
+      return (
+        String(data).slice(0, availableLabelWidth / APPROX_FONT_WIDTH) + "…"
+      )
     } else {
       String(data)
     }

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -217,7 +217,7 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
       layer.destroyLayer(_chart)
     }
 
-    if(_chart.map()) {
+    if (_chart.map()) {
       _chart.map().remove()
     }
   }
@@ -271,7 +271,7 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
     const geoTable = _layer.getState().encoding.geoTable
     const geoCol = _layer.getState().encoding.geocol
 
-    const preflightQuery = `SELECT COUNT(*) AS n FROM ${geoTable} WHERE ST_XMax(${geoTable}.${geoCol}) >= ${ mapBounds._sw.lng } AND ST_XMin(${geoTable}.${geoCol}) <= ${ mapBounds._ne.lng } AND ST_YMax(${geoTable}.${geoCol}) >= ${ mapBounds._sw.lat } AND ST_YMin(${geoTable}.${geoCol}) <= ${ mapBounds._ne.lat }`
+    const preflightQuery = `SELECT COUNT(*) AS n FROM ${geoTable} WHERE ST_XMax(${geoTable}.${geoCol}) >= ${mapBounds._sw.lng} AND ST_XMin(${geoTable}.${geoCol}) <= ${mapBounds._ne.lng} AND ST_YMax(${geoTable}.${geoCol}) >= ${mapBounds._sw.lat} AND ST_YMin(${geoTable}.${geoCol}) <= ${mapBounds._ne.lat}`
 
     return chart.con().queryAsync(preflightQuery, {})
   }
@@ -295,16 +295,24 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
 
   _chart.setDataAsync((group, callback) => {
     const layers = _chart.getAllLayers()
-    const polyLayers = layers.length ? _.filter(layers, (layer) => layer.getState().mark.type === "poly" ) : null
-    if (polyLayers && polyLayers.length) { // add bboxCount to poly layers run sample
+    const polyLayers = layers.length
+      ? _.filter(layers, layer => layer.getState().mark.type === "poly")
+      : null
+    if (polyLayers && polyLayers.length) {
+      // add bboxCount to poly layers run sample
 
-      const countsPromise = polyLayers.map(currentLayer => getCountFromBoundingBox(_chart, currentLayer))
+      const countsPromise = polyLayers.map(currentLayer =>
+        getCountFromBoundingBox(_chart, currentLayer)
+      )
 
       Promise.all(countsPromise).then(resArr => {
         resArr.forEach((res, index) => {
           const count = res && res[0] && res[0].n
           const currentLayer = polyLayers[index]
-          currentLayer.setState({...currentLayer.getState(), bboxCount: count})
+          currentLayer.setState({
+            ...currentLayer.getState(),
+            bboxCount: count
+          })
         })
         handleRenderVega(callback)
       })

--- a/src/core/core-async.unit.spec.js
+++ b/src/core/core-async.unit.spec.js
@@ -20,7 +20,7 @@ describe("Core Async", () => {
     // "done() called multiple times" if an expectation fails instead of
     // showing the information about the failed expectation.
     function asyncTestWrapper(tester) {
-      return (done) => {
+      return done => {
         let hasError = false
         try {
           return tester(val => {
@@ -40,44 +40,53 @@ describe("Core Async", () => {
     })
 
     describe("_run", () => {
-      it("should set and unset the group", asyncTestWrapper((done) => {
-        tracker._run("group", false, runner).then(() => {
-          expect(Object.keys(tracker.groups)).to.be.empty
-          done()
-        })
-        expect(tracker.groups).to.have.keys("group")
-      }))
-
-      it("should set and unset all", asyncTestWrapper((done) => {
-        tracker._run(null, true, runner).then(() => {
-          expect(tracker.all).to.be.null
-          done()
-        })
-        expect(tracker.all).to.not.be.null
-      }))
-
-      it("should set and unset multiple groups", asyncTestWrapper((done) => {
-        let finished = 0
-        const doneAll = () => {
-          if (++finished === 3) {
+      it(
+        "should set and unset the group",
+        asyncTestWrapper(done => {
+          tracker._run("group", false, runner).then(() => {
+            expect(Object.keys(tracker.groups)).to.be.empty
             done()
-          }
-        }
+          })
+          expect(tracker.groups).to.have.keys("group")
+        })
+      )
 
-        tracker._run("group1", false, runner).then(() => {
-          expect(tracker.groups).to.not.have.keys("group1")
-          doneAll()
+      it(
+        "should set and unset all",
+        asyncTestWrapper(done => {
+          tracker._run(null, true, runner).then(() => {
+            expect(tracker.all).to.be.null
+            done()
+          })
+          expect(tracker.all).to.not.be.null
         })
-        tracker._run("group2", false, runner).then(() => {
-          expect(tracker.groups).to.not.have.keys("group2")
-          doneAll()
+      )
+
+      it(
+        "should set and unset multiple groups",
+        asyncTestWrapper(done => {
+          let finished = 0
+          const doneAll = () => {
+            if (++finished === 3) {
+              done()
+            }
+          }
+
+          tracker._run("group1", false, runner).then(() => {
+            expect(tracker.groups).to.not.have.keys("group1")
+            doneAll()
+          })
+          tracker._run("group2", false, runner).then(() => {
+            expect(tracker.groups).to.not.have.keys("group2")
+            doneAll()
+          })
+          tracker._run("group3", false, runner).then(() => {
+            expect(tracker.groups).to.not.have.keys("group3")
+            doneAll()
+          })
+          expect(tracker.groups).to.have.keys("group1", "group2", "group3")
         })
-        tracker._run("group3", false, runner).then(() => {
-          expect(tracker.groups).to.not.have.keys("group3")
-          doneAll()
-        })
-        expect(tracker.groups).to.have.keys("group1", "group2", "group3")
-      }))
+      )
     })
 
     describe("shouldStart", () => {
@@ -86,22 +95,31 @@ describe("Core Async", () => {
         expect(tracker.shouldStart(null, true)).to.be.true
       })
 
-      it("should return false if a group is already tracked", asyncTestWrapper((done) => {
-        tracker._run("group", false, runner).then(done)
-        expect(tracker.shouldStart("group")).to.be.false
-        expect(tracker.shouldStart(null, true)).to.be.false
-      }))
+      it(
+        "should return false if a group is already tracked",
+        asyncTestWrapper(done => {
+          tracker._run("group", false, runner).then(done)
+          expect(tracker.shouldStart("group")).to.be.false
+          expect(tracker.shouldStart(null, true)).to.be.false
+        })
+      )
 
-      it("should return true even if another group is tracked", asyncTestWrapper((done) => {
-        tracker._run("group1", false, runner).then(done)
-        expect(tracker.shouldStart("group2")).to.be.true
-      }))
+      it(
+        "should return true even if another group is tracked",
+        asyncTestWrapper(done => {
+          tracker._run("group1", false, runner).then(done)
+          expect(tracker.shouldStart("group2")).to.be.true
+        })
+      )
 
-      it("should return false if 'all' is tracked", asyncTestWrapper((done) => {
-        tracker._run(null, true, runner).then(done)
-        expect(tracker.shouldStart("group")).to.be.false
-        expect(tracker.shouldStart(null, true)).to.be.false
-      }))
+      it(
+        "should return false if 'all' is tracked",
+        asyncTestWrapper(done => {
+          tracker._run(null, true, runner).then(done)
+          expect(tracker.shouldStart("group")).to.be.false
+          expect(tracker.shouldStart(null, true)).to.be.false
+        })
+      )
     })
 
     describe("isEmpty", () => {
@@ -110,155 +128,182 @@ describe("Core Async", () => {
         expect(tracker.isEmpty("group")).to.be.true
       })
 
-      it("should return false if a group is tracked", asyncTestWrapper((done) => {
-        tracker._run("group", false, runner).then(done)
-        expect(tracker.isEmpty()).to.be.false
-        expect(tracker.isEmpty("group")).to.be.false
-        expect(tracker.isEmpty("group2")).to.be.true
-      }))
+      it(
+        "should return false if a group is tracked",
+        asyncTestWrapper(done => {
+          tracker._run("group", false, runner).then(done)
+          expect(tracker.isEmpty()).to.be.false
+          expect(tracker.isEmpty("group")).to.be.false
+          expect(tracker.isEmpty("group2")).to.be.true
+        })
+      )
 
-      it("should return false if all is tracked", asyncTestWrapper((done) => {
-        tracker._run(null, true, runner).then(done)
-        expect(tracker.isEmpty()).to.be.false
-        expect(tracker.isEmpty("group")).to.be.false
-        expect(tracker.isEmpty("group2")).to.be.false
-      }))
+      it(
+        "should return false if all is tracked",
+        asyncTestWrapper(done => {
+          tracker._run(null, true, runner).then(done)
+          expect(tracker.isEmpty()).to.be.false
+          expect(tracker.isEmpty("group")).to.be.false
+          expect(tracker.isEmpty("group2")).to.be.false
+        })
+      )
     })
 
     describe("start", () => {
-      it("should start running when nothing is tracked", asyncTestWrapper((done) => {
-        const spyRunner = chai.spy(runner)
-        tracker.start("group", false, spyRunner).then(() => {
-          expect(spyRunner).to.have.been.called.once
-          expect(tracker.groups).to.not.have.keys("group")
-          done()
-        })
-        expect(tracker.groups).to.have.keys("group")
-      }))
-
-      it("should start running even if a different group is running", asyncTestWrapper((done) => {
-        const spyRunner = chai.spy(runner)
-
-        let finished = 0
-        const doneAll = () => {
-          if (++finished === 2) {
-            expect(spyRunner).to.have.been.called.twice
-            expect(tracker.groups).to.not.have.keys("group1", "group2")
+      it(
+        "should start running when nothing is tracked",
+        asyncTestWrapper(done => {
+          const spyRunner = chai.spy(runner)
+          tracker.start("group", false, spyRunner).then(() => {
+            expect(spyRunner).to.have.been.called.once
+            expect(tracker.groups).to.not.have.keys("group")
             done()
+          })
+          expect(tracker.groups).to.have.keys("group")
+        })
+      )
+
+      it(
+        "should start running even if a different group is running",
+        asyncTestWrapper(done => {
+          const spyRunner = chai.spy(runner)
+
+          let finished = 0
+          const doneAll = () => {
+            if (++finished === 2) {
+              expect(spyRunner).to.have.been.called.twice
+              expect(tracker.groups).to.not.have.keys("group1", "group2")
+              done()
+            }
           }
-        }
 
-        tracker.start("group1", false, spyRunner).then(doneAll)
-        tracker.start("group2", false, spyRunner).then(doneAll)
-        expect(tracker.groups).to.have.keys("group1", "group2")
-      }))
+          tracker.start("group1", false, spyRunner).then(doneAll)
+          tracker.start("group2", false, spyRunner).then(doneAll)
+          expect(tracker.groups).to.have.keys("group1", "group2")
+        })
+      )
 
-      it("should start running a group after all has completed", asyncTestWrapper((done) => {
-        const spyRunner = chai.spy(runner)
-        const runner2 = () => {
-          expect(spyRunner).to.have.been.called.once
+      it(
+        "should start running a group after all has completed",
+        asyncTestWrapper(done => {
+          const spyRunner = chai.spy(runner)
+          const runner2 = () => {
+            expect(spyRunner).to.have.been.called.once
+            expect(tracker.all).to.be.null
+            return runner().then(() => {
+              expect(tracker.groups).to.have.keys("group")
+            })
+          }
+
+          tracker.start(null, true, spyRunner)
+          tracker.start("group", false, runner2).then(() => {
+            expect(tracker.groups).to.not.have.keys("group")
+            done()
+          })
+          expect(tracker.all).to.not.be.null
+          expect(tracker.pendingGroups).to.have.keys("group")
+        })
+      )
+
+      it(
+        "should start running all after all groups complete",
+        asyncTestWrapper(done => {
+          const spyRunner = chai.spy(runner)
+          const runner2 = () => {
+            expect(spyRunner).to.have.been.called.twice
+            expect(Object.keys(tracker.groups)).to.be.empty
+            expect(tracker.pendingAll).to.be.null
+            return runner().then(() => {
+              expect(tracker.all).to.not.be.null
+            })
+          }
+
+          tracker.start("group1", false, spyRunner)
+          tracker.start("group2", false, spyRunner)
+          tracker.start(null, true, runner2).then(() => {
+            expect(tracker.all).to.be.null
+            done()
+          })
           expect(tracker.all).to.be.null
-          return runner().then(() => {
-            expect(tracker.groups).to.have.keys("group")
-          })
-        }
-
-        tracker.start(null, true, spyRunner)
-        tracker.start("group", false, runner2).then(() => {
-          expect(tracker.groups).to.not.have.keys("group")
-          done()
+          expect(tracker.pendingAll).to.not.be.null
+          expect(tracker.groups).to.have.keys("group1", "group2")
         })
-        expect(tracker.all).to.not.be.null
-        expect(tracker.pendingGroups).to.have.keys("group")
-      }))
+      )
 
-      it("should start running all after all groups complete", asyncTestWrapper((done) => {
-        const spyRunner = chai.spy(runner)
-        const runner2 = () => {
-          expect(spyRunner).to.have.been.called.twice
-          expect(Object.keys(tracker.groups)).to.be.empty
-          expect(tracker.pendingAll).to.be.null
-          return runner().then(() => {
-            expect(tracker.all).to.not.be.null
+      it(
+        "should start running a group after the previous run completes",
+        asyncTestWrapper(done => {
+          const spyRunner = chai.spy(runner)
+          const runner2 = () => {
+            expect(spyRunner).to.have.been.called.once
+            expect(tracker.groups).to.not.have.keys("group")
+            expect(tracker.pendingGroups).to.not.have.keys("group")
+            return runner().then(() => {
+              expect(tracker.groups).to.have.keys("group")
+            })
+          }
+
+          tracker.start("group", false, spyRunner)
+          tracker.start("group", false, runner2).then(() => {
+            expect(tracker.groups).to.not.have.keys("group")
+            done()
           })
-        }
-
-        tracker.start("group1", false, spyRunner)
-        tracker.start("group2", false, spyRunner)
-        tracker.start(null, true, runner2).then(() => {
-          expect(tracker.all).to.be.null
-          done()
+          expect(tracker.groups).to.have.keys("group")
+          expect(tracker.pendingGroups).to.have.keys("group")
         })
-        expect(tracker.all).to.be.null
-        expect(tracker.pendingAll).to.not.be.null
-        expect(tracker.groups).to.have.keys("group1", "group2")
-      }))
+      )
 
-      it("should start running a group after the previous run completes", asyncTestWrapper((done) => {
-        const spyRunner = chai.spy(runner)
-        const runner2 = () => {
-          expect(spyRunner).to.have.been.called.once
-          expect(tracker.groups).to.not.have.keys("group")
-          expect(tracker.pendingGroups).to.not.have.keys("group")
-          return runner().then(() => {
-            expect(tracker.groups).to.have.keys("group")
-          })
-        }
-
-        tracker.start("group", false, spyRunner)
-        tracker.start("group", false, runner2).then(() => {
-          expect(tracker.groups).to.not.have.keys("group")
-          done()
-        })
-        expect(tracker.groups).to.have.keys("group")
-        expect(tracker.pendingGroups).to.have.keys("group")
-      }))
-
-      it("should only run pending processes once no matter how many times queued", asyncTestWrapper(done => {
-        const spyRunner = chai.spy(runner)
-        const finished = () => {
-          // this should only be called once... if not, we'll get a "done()
-          // called multiple times" error
-          expect(spyRunner).to.be.called.once
-          expect(tracker.groups).to.not.have.keys("group")
-          expect(tracker.pendingGroups).to.not.have.keys("group")
-          done()
-        }
-
-        tracker.start("group", false, runner)
-
-        const promise1 = tracker.start("group", false, spyRunner)
-        const promise2 = tracker.start("group", false, spyRunner)
-        expect(tracker.groups).to.have.keys("group")
-        expect(tracker.pendingGroups).to.have.keys("group")
-        expect(promise1).to.equal(promise2)
-
-        promise2.then(finished)
-      }))
-
-      it("should run a pending process even if the running process fails", asyncTestWrapper(done => {
-        // if this test times out, it's probably because verifyCatch is not
-        // getting run correctly.
-        let finished = 0
-        const spyRunner = chai.spy(() => Promise.reject('error'))
-        const verifyCatch = err => {
-          expect(err).to.eql("error")
-          doneAll()
-        }
-        const doneAll = () => {
-          if (++finished === 2) {
+      it(
+        "should only run pending processes once no matter how many times queued",
+        asyncTestWrapper(done => {
+          const spyRunner = chai.spy(runner)
+          const finished = () => {
+            // this should only be called once... if not, we'll get a "done()
+            // called multiple times" error
             expect(spyRunner).to.be.called.once
             expect(tracker.groups).to.not.have.keys("group")
             expect(tracker.pendingGroups).to.not.have.keys("group")
             done()
           }
-        }
 
-        tracker.start("group", false, spyRunner).catch(verifyCatch)
-        tracker.start("group", false, runner).then(doneAll)
-        expect(tracker.groups).to.have.keys("group")
-        expect(tracker.pendingGroups).to.have.keys("group")
-      }))
+          tracker.start("group", false, runner)
+
+          const promise1 = tracker.start("group", false, spyRunner)
+          const promise2 = tracker.start("group", false, spyRunner)
+          expect(tracker.groups).to.have.keys("group")
+          expect(tracker.pendingGroups).to.have.keys("group")
+          expect(promise1).to.equal(promise2)
+
+          promise2.then(finished)
+        })
+      )
+
+      it(
+        "should run a pending process even if the running process fails",
+        asyncTestWrapper(done => {
+          // if this test times out, it's probably because verifyCatch is not
+          // getting run correctly.
+          let finished = 0
+          const spyRunner = chai.spy(() => Promise.reject("error"))
+          const verifyCatch = err => {
+            expect(err).to.eql("error")
+            doneAll()
+          }
+          const doneAll = () => {
+            if (++finished === 2) {
+              expect(spyRunner).to.be.called.once
+              expect(tracker.groups).to.not.have.keys("group")
+              expect(tracker.pendingGroups).to.not.have.keys("group")
+              done()
+            }
+          }
+
+          tracker.start("group", false, spyRunner).catch(verifyCatch)
+          tracker.start("group", false, runner).then(doneAll)
+          expect(tracker.groups).to.have.keys("group")
+          expect(tracker.pendingGroups).to.have.keys("group")
+        })
+      )
     })
   })
 

--- a/src/mixins/base-mixin.js
+++ b/src/mixins/base-mixin.js
@@ -1367,20 +1367,20 @@ export default function baseMixin(_chart) {
    * @instance
    * @param {*} datum
    */
-   _chart.onClick = function(datum) {
-     // filtering on dimension will have key, but for filtering on measures which is on column doesn't. Thus, the filter is the column value only
-     const values = _chart.keyAccessor()(datum);
-     let filter = null;
-     if (
-       (Array.isArray(values) && values.length) ||
-       (!Array.isArray(values) && values !== undefined)
-     ) {
-       filter = values;
-     } else {
-       filter = datum;
-     }
-     _chart.handleFilterClick(d3.event, filter);
-   };
+  _chart.onClick = function(datum) {
+    // filtering on dimension will have key, but for filtering on measures which is on column doesn't. Thus, the filter is the column value only
+    const values = _chart.keyAccessor()(datum)
+    let filter = null
+    if (
+      (Array.isArray(values) && values.length) ||
+      (!Array.isArray(values) && values !== undefined)
+    ) {
+      filter = values
+    } else {
+      filter = datum
+    }
+    _chart.handleFilterClick(d3.event, filter)
+  }
 
   /**
    * Set or get the filter handler. The filter handler is a function that performs the filter action
@@ -1899,7 +1899,7 @@ export default function baseMixin(_chart) {
 
   _chart.getMeasureName = function() {
     const measure = _chart.group().reduce()
-    return (measure && measure[0]) ? measure[0].measureName : null
+    return measure && measure[0] ? measure[0].measureName : null
   }
 
   _chart = chartLegendMixin(

--- a/src/mixins/label-mixin.js
+++ b/src/mixins/label-mixin.js
@@ -161,8 +161,7 @@ export default function labelMixin(chart) {
         this.select()
       })
       .on("keyup", function() {
-        d3
-          .select(this.parentNode)
+        d3.select(this.parentNode)
           .select("span")
           .text(this.value)
         if (d3.event.keyCode === 13) {

--- a/src/mixins/lock-axis-mixin.js
+++ b/src/mixins/lock-axis-mixin.js
@@ -234,9 +234,8 @@ export default function lockAxisMixin(chart) {
     lockWrapper
       .append("div")
       .attr("class", `lock-toggle type-${type}`)
-      .classed(
-        "is-locked",
-        () => (type === "y" ? !chart.elasticY() : !chart.elasticX())
+      .classed("is-locked", () =>
+        type === "y" ? !chart.elasticY() : !chart.elasticX()
       )
       .style("top", iconPosition.top)
       .style("left", iconPosition.left)

--- a/src/mixins/map-mixin.js
+++ b/src/mixins/map-mixin.js
@@ -119,7 +119,7 @@ export default function mapMixin(
       "boxZoom",
       "dragPan",
       "keyboard",
-      "doubleClickZoom",
+      "doubleClickZoom"
     ]
     _interactionsEnabled = Boolean(enableInteractions)
 
@@ -275,8 +275,11 @@ export default function mapMixin(
     mapboxlogo.target = "_blank"
     mapboxlogo.innerHTML = "Mapbox"
 
-    const existingLogo = (_map && _map._container) ? _map._container.querySelector('.mapbox-maplogo') : null;
-    if(!existingLogo) {
+    const existingLogo =
+      _map && _map._container
+        ? _map._container.querySelector(".mapbox-maplogo")
+        : null
+    if (!existingLogo) {
       _chart.root()[0][0].appendChild(mapboxlogo)
     }
 
@@ -343,12 +346,20 @@ export default function mapMixin(
             xdim.filter([_chart._minCoord[0], _chart._maxCoord[0]])
             ydim.filter([_chart._minCoord[1], _chart._maxCoord[1]])
           }
-        }
-        else if(typeof layer.viewBoxDim === "function" && layer.getState().data.length < 2) { // spatial filter on only single data source
+        } else if (
+          typeof layer.viewBoxDim === "function" &&
+          layer.getState().data.length < 2
+        ) {
+          // spatial filter on only single data source
           const viewBoxDim = layer.viewBoxDim()
-          if(viewBoxDim !== null) {
+          if (viewBoxDim !== null) {
             redrawall = true
-            viewBoxDim.filterST_Min_ST_Max({lonMin: bounds._sw.lng, lonMax: bounds._ne.lng, latMin: bounds._sw.lat, latMax: bounds._ne.lat})
+            viewBoxDim.filterST_Min_ST_Max({
+              lonMin: bounds._sw.lng,
+              lonMax: bounds._ne.lng,
+              latMin: bounds._sw.lat,
+              latMax: bounds._ne.lat
+            })
           }
         }
       })
@@ -366,8 +377,14 @@ export default function mapMixin(
         resetRedrawStack()
         console.log("on move event redrawall error:", error)
       })
-    } else if(_viewBoxDim !== null && layer.getState().data.length < 2) { // spatial filter on only single data source
-      _viewBoxDim.filterST_Min_ST_Max({lonMin: _chart._minCoord[0],lonMax: _chart._maxCoord[0], latMin: _chart._minCoord[1], latMax: _chart._maxCoord[1]})
+    } else if (_viewBoxDim !== null && layer.getState().data.length < 2) {
+      // spatial filter on only single data source
+      _viewBoxDim.filterST_Min_ST_Max({
+        lonMin: _chart._minCoord[0],
+        lonMax: _chart._maxCoord[0],
+        latMin: _chart._minCoord[1],
+        latMax: _chart._maxCoord[1]
+      })
       redrawAllAsync(_chart.chartGroup()).catch(error => {
         resetRedrawStack()
         console.log("on move event redrawall error:", error)
@@ -437,7 +454,7 @@ export default function mapMixin(
     if (_chart.svg()) {
       _chart.svg().remove()
     }
-    if(_chart.map()) {
+    if (_chart.map()) {
       const mapContainer = d3.select(_chart.map().getCanvasContainer())
       const svg = mapContainer.append("svg").attr("class", "poly-svg")
       svg.attr("width", _chart.width()).attr("height", _chart.height())
@@ -453,7 +470,7 @@ export default function mapMixin(
       const yDiff = this._maxCoord[1] - this._minCoord[1]
       var projectedPoint = this.conv4326To900913(input)
       return [
-        (projectedPoint[0] - this._minCoord[0]) / xDiff * this.width(),
+        ((projectedPoint[0] - this._minCoord[0]) / xDiff) * this.width(),
         (1.0 - (projectedPoint[1] - this._minCoord[1]) / yDiff) * this.height()
       ]
     } else {
@@ -465,24 +482,36 @@ export default function mapMixin(
   _chart._setOverlay = function(data, bounds, browser, redraw) {
     const map = _chart.map()
 
-    const allMapboxCanvasContainer = document.getElementsByClassName('mapboxgl-canvas-container')
-    const chartIdFromCanvasContainer = _chart.selectAll('.mapboxgl-canvas-container')[0].parentNode.id
+    const allMapboxCanvasContainer = document.getElementsByClassName(
+      "mapboxgl-canvas-container"
+    )
+    const chartIdFromCanvasContainer = _chart.selectAll(
+      ".mapboxgl-canvas-container"
+    )[0].parentNode.id
 
-    const chartMapboxCanvasContainer = _.filter(allMapboxCanvasContainer, (mbcc) =>
-      mbcc.parentNode.id === chartIdFromCanvasContainer || mbcc.parentNode.parentNode.id === chartIdFromCanvasContainer
+    const chartMapboxCanvasContainer = _.filter(
+      allMapboxCanvasContainer,
+      mbcc =>
+        mbcc.parentNode.id === chartIdFromCanvasContainer ||
+        mbcc.parentNode.parentNode.id === chartIdFromCanvasContainer
     )
 
-    const allMapboxCanvas = document.getElementsByClassName('mapboxgl-canvas')
-    const chartIdFromCanvas = _chart.selectAll('.mapboxgl-canvas')[0].parentNode.id
+    const allMapboxCanvas = document.getElementsByClassName("mapboxgl-canvas")
+    const chartIdFromCanvas = _chart.selectAll(".mapboxgl-canvas")[0].parentNode
+      .id
 
-    const chartMapboxCanvas = _.filter(allMapboxCanvas, (mbc) =>
-      mbc.parentNode.id === chartIdFromCanvas || mbc.parentNode.parentNode.id === chartIdFromCanvas
+    const chartMapboxCanvas = _.filter(
+      allMapboxCanvas,
+      mbc =>
+        mbc.parentNode.id === chartIdFromCanvas ||
+        mbc.parentNode.parentNode.id === chartIdFromCanvas
     )
 
-    if(chartMapboxCanvasContainer.length > 1) { // we use only one canvas for the chart map, thus remove extra
+    if (chartMapboxCanvasContainer.length > 1) {
+      // we use only one canvas for the chart map, thus remove extra
       chartMapboxCanvasContainer[0].remove()
     }
-    if(chartMapboxCanvas.length > 1){
+    if (chartMapboxCanvas.length > 1) {
       chartMapboxCanvas[0].remove()
     }
 
@@ -669,7 +698,7 @@ export default function mapMixin(
 
     _mapboxgl.accessToken = _mapboxAccessToken
     if (!_mapboxgl.supported()) {
-      throw {name: "WebGL", message: 'WebGL Not Enabled'}
+      throw { name: "WebGL", message: "WebGL Not Enabled" }
     } else {
       initMap()
     }

--- a/src/mixins/multiple-key-label-mixin.js
+++ b/src/mixins/multiple-key-label-mixin.js
@@ -24,11 +24,13 @@ function format(_value, _key, numberFormatter, dateFormatter) {
     customFormatter = numberFormatter
   }
 
-  return (!isExtract && customFormatter && customFormatter(value, key)) || formatDataValue(_value)
+  return (
+    (!isExtract && customFormatter && customFormatter(value, key)) ||
+    formatDataValue(_value)
+  )
 }
 
 export default function multipleKeysLabelMixin(_chart) {
-
   function label(d) {
     const numberFormatter = _chart && _chart.valueFormatter()
     const dateFormatter = _chart && _chart.dateFormatter()
@@ -42,7 +44,12 @@ export default function multipleKeysLabelMixin(_chart) {
     let i = 0
     for (const key in d) {
       if (d.hasOwnProperty(key) && key.indexOf("key") > INDEX_NONE) {
-        const formatted = format(d[key], dimensionNames[i], numberFormatter, dateFormatter)
+        const formatted = format(
+          d[key],
+          dimensionNames[i],
+          numberFormatter,
+          dateFormatter
+        )
         keysStr.push(formatted)
       }
       i++

--- a/src/mixins/raster-draw-mixin.js
+++ b/src/mixins/raster-draw-mixin.js
@@ -134,9 +134,7 @@ export function rasterDrawMixin(chart) {
                 LatLonUtils.conv900913To4326(pos, pos)
                 const meters = shape.radius * 1000
                 filterObj.shapeFilters.push(
-                  `DISTANCE_IN_METERS(${pos[0]}, ${
-                    pos[1]
-                  }, ${px}, ${py}) < ${meters}`
+                  `DISTANCE_IN_METERS(${pos[0]}, ${pos[1]}, ${px}, ${py}) < ${meters}`
                 )
               } else if (shape instanceof MapdDraw.Circle) {
                 const radsqr = Math.pow(shape.radius, 2)
@@ -217,9 +215,11 @@ export function rasterDrawMixin(chart) {
             })
           }
         }
-      } else if (!layer.layerType ||
+      } else if (
+        !layer.layerType ||
         typeof layer.layerType !== "function" ||
-        layer.layerType() === "lines") {
+        layer.layerType() === "lines"
+      ) {
         if (layer.getState().data.length < 2) {
           let crossFilter = null
           let filterObj = null
@@ -239,7 +239,7 @@ export function rasterDrawMixin(chart) {
             filterObj = coordFilters.get(crossFilter)
             if (!filterObj) {
               filterObj = {
-                coordFilter: crossFilter,
+                coordFilter: crossFilter
               }
               coordFilters.set(crossFilter, filterObj)
               filterObj.shapeFilters = []
@@ -253,9 +253,9 @@ export function rasterDrawMixin(chart) {
                 const radiusInKm = shape.radius
                 const shapeFilter = {
                   spatialRelAndMeas: "filterST_Distance",
-                  filters: {point: [pos[0], pos[1]], distanceInKm: radiusInKm}
+                  filters: { point: [pos[0], pos[1]], distanceInKm: radiusInKm }
                 }
-                
+
                 if (!_.find(filterObj.shapeFilters, shapeFilter)) {
                   filterObj.shapeFilters.push(shapeFilter)
                 }
@@ -272,7 +272,10 @@ export function rasterDrawMixin(chart) {
                   }
                   convertedVerts.push([p0[0], p0[1]])
                 })
-                const shapeFilter = {spatialRelAndMeas: "filterST_Contains", filters: convertedVerts}
+                const shapeFilter = {
+                  spatialRelAndMeas: "filterST_Contains",
+                  filters: convertedVerts
+                }
 
                 if (!_.find(filterObj.shapeFilters, shapeFilter)) {
                   filterObj.shapeFilters.push(shapeFilter)
@@ -286,7 +289,8 @@ export function rasterDrawMixin(chart) {
 
     coordFilters.forEach(filterObj => {
       if (
-        filterObj.px && filterObj.py &&
+        filterObj.px &&
+        filterObj.py &&
         filterObj.px.length &&
         filterObj.py.length &&
         filterObj.shapeFilters.length
@@ -303,16 +307,15 @@ export function rasterDrawMixin(chart) {
           )
           .map(
             (e, i) =>
-              `(${e.px} IS NOT NULL AND ${
-                e.py
-              } IS NOT NULL AND (${shapeFilterStmt}))`
+              `(${e.px} IS NOT NULL AND ${e.py} IS NOT NULL AND (${shapeFilterStmt}))`
           )
           .join(" AND ")
         filterObj.coordFilter.filter([filterStmt])
         filterObj.px = []
         filterObj.py = []
         filterObj.shapeFilters = []
-      } else if (filterObj.coordFilter &&
+      } else if (
+        filterObj.coordFilter &&
         filterObj.shapeFilters &&
         filterObj.shapeFilters.length &&
         filterObj.shapeFilters[0].spatialRelAndMeas
@@ -535,10 +538,18 @@ export function rasterDrawMixin(chart) {
       })
       if (coordFilters) {
         coordFilters.forEach(filterObj => {
-          if (filterObj.coordFilter && 'spatialRelAndMeas' in filterObj.shapeFilters) {
+          if (
+            filterObj.coordFilter &&
+            "spatialRelAndMeas" in filterObj.shapeFilters
+          ) {
             filterObj.coordFilter.filterSpatial()
             const bounds = chart.map().getBounds()
-            filterObj.coordFilter.filterST_Min_ST_Max({lonMin: bounds._sw.lng, lonMax: bounds._ne.lng, latMin: bounds._sw.lat, latMax: bounds._ne.lat})
+            filterObj.coordFilter.filterST_Min_ST_Max({
+              lonMin: bounds._sw.lng,
+              lonMax: bounds._ne.lng,
+              latMin: bounds._sw.lat,
+              latMax: bounds._ne.lat
+            })
           } else {
             filterObj.coordFilter.filter()
           }
@@ -549,7 +560,7 @@ export function rasterDrawMixin(chart) {
       drawEngine.deleteAllShapes()
 
       origFilterFunc(Symbol.for("clear"))
-      
+
       shapes.forEach(shape => {
         chart.deleteFilterShape(shape)
       })

--- a/src/mixins/raster-layer-heatmap-mixin.js
+++ b/src/mixins/raster-layer-heatmap-mixin.js
@@ -10,8 +10,7 @@ const EARTH_DIAMETER = 40075000
 function getPixelSize(neLat, width, zoom) {
   return Math.max(
     MIN_AREA_IN_METERS /
-      (EARTH_DIAMETER *
-        Math.cos(neLat * Math.PI / 180) /
+      ((EARTH_DIAMETER * Math.cos((neLat * Math.PI) / 180)) /
         (width * Math.pow(2, zoom))),
     1.0
   )
@@ -20,7 +19,7 @@ function getPixelSize(neLat, width, zoom) {
 function getMarkHeight(type, width) {
   switch (type) {
     case "hex":
-      return 2 * width / Math.sqrt(3.0)
+      return (2 * width) / Math.sqrt(3.0)
     default:
       return width
   }
@@ -181,20 +180,22 @@ export default function rasterLayerHeatmapMixin(_layer) {
       height
     }
 
-    vega.data = [{
-      name: datalayerName,
-      sql: _layer.genSQL({
-        table,
-        width,
-        height,
-        min,
-        max,
-        filter,
-        globalFilter,
-        neLat,
-        zoom
-      })
-    }]
+    vega.data = [
+      {
+        name: datalayerName,
+        sql: _layer.genSQL({
+          table,
+          width,
+          height,
+          min,
+          max,
+          filter,
+          globalFilter,
+          neLat,
+          zoom
+        })
+      }
+    ]
 
     if (autocolors) {
       vega.data.push({
@@ -202,10 +203,10 @@ export default function rasterLayerHeatmapMixin(_layer) {
         source: datalayerName,
         transform: [
           {
-            type:   "aggregate",
+            type: "aggregate",
             fields: ["color", "color", "color", "color"],
-            ops:    ["min", "max", "avg", "stddev"],
-            as:     ["minimum", "maximum", "mean", "deviation"]
+            ops: ["min", "max", "avg", "stddev"],
+            as: ["minimum", "maximum", "mean", "deviation"]
           },
           {
             type: "formula",
@@ -226,10 +227,9 @@ export default function rasterLayerHeatmapMixin(_layer) {
       {
         name: colorScaleName,
         type: state.encoding.color.type,
-        domain:
-          autocolors 
-            ? {data: getStatsLayerName(), fields: ["mincolor", "maxcolor"]}
-            : state.encoding.color.scale.domain,
+        domain: autocolors
+          ? { data: getStatsLayerName(), fields: ["mincolor", "maxcolor"] }
+          : state.encoding.color.scale.domain,
         range: state.encoding.color.scale.range.map(c =>
           adjustOpacity(c, state.encoding.color.scale.opacity)
         ),

--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -5,11 +5,12 @@ import {
   renderAttributes,
   getScales,
   getSizeScaleName,
-  getColorScaleName, adjustOpacity
-} from "../utils/utils-vega";
-import {lastFilteredSize, setLastFilteredSize} from "../core/core-async";
-import {parser} from "../utils/utils";
-import * as d3 from "d3";
+  getColorScaleName,
+  adjustOpacity
+} from "../utils/utils-vega"
+import { lastFilteredSize, setLastFilteredSize } from "../core/core-async"
+import { parser } from "../utils/utils"
+import * as d3 from "d3"
 
 const AUTOSIZE_DOMAIN_DEFAULTS = [100000, 1000]
 const AUTOSIZE_RANGE_DEFAULTS = [1.0, 3.0]
@@ -25,7 +26,10 @@ function getSizing(
 ) {
   if (typeof sizeAttr === "number") {
     return sizeAttr
-  } else if (typeof sizeAttr === "object" && (sizeAttr.type === "quantitative" || sizeAttr.type === "custom")) {
+  } else if (
+    typeof sizeAttr === "object" &&
+    (sizeAttr.type === "quantitative" || sizeAttr.type === "custom")
+  ) {
     return {
       scale: getSizeScaleName(layerName),
       field: "strokeWidth"
@@ -63,19 +67,12 @@ function getColor(color, layerName) {
     }
   } else if (typeof color === "object") {
     return adjustOpacity(color.value, color.opacity)
-  }
-  else {
+  } else {
     return color
   }
 }
 
-function getTransforms(
-  table,
-  filter,
-  globalFilter,
-  state,
-  lastFilteredSize
-) {
+function getTransforms(table, filter, globalFilter, state, lastFilteredSize) {
   const transforms = []
   const { transform } = state
   const { size, color, geocol, geoTable } = state.encoding
@@ -94,22 +91,29 @@ function getTransforms(
     return state.data.length > 1
   }
 
-  const groupbyDim = state.transform.groupby ? state.transform.groupby.map((g, i) => ({
-    type: "project",
-    expr: `${state.data[0].table}.${g}`,
-    as: `key${i}`
-  })) : []
+  const groupbyDim = state.transform.groupby
+    ? state.transform.groupby.map((g, i) => ({
+        type: "project",
+        expr: `${state.data[0].table}.${g}`,
+        as: `key${i}`
+      }))
+    : []
 
   const groupby = doJoin()
-    ? [{
-      type: "project",
-      expr: `${state.data[0].table}.${state.data[0].attr}`,
-      as: "key0"
-    }]
+    ? [
+        {
+          type: "project",
+          expr: `${state.data[0].table}.${state.data[0].attr}`,
+          as: "key0"
+        }
+      ]
     : groupbyDim
 
-  if (typeof size === "object" && (size.type === "quantitative" || size.type === "custom")) {
-    if(groupby.length > 0 && size.type === "quantitative") {
+  if (
+    typeof size === "object" &&
+    (size.type === "quantitative" || size.type === "custom")
+  ) {
+    if (groupby.length > 0 && size.type === "quantitative") {
       fields.push(`${state.data[0].table}.${size.field}`)
       alias.push("strokeWidth")
       ops.push(size.aggregate)
@@ -126,13 +130,13 @@ function getTransforms(
     typeof color === "object" &&
     (color.type === "quantitative" || color.type === "ordinal")
   ) {
-    if(groupby.length > 0 && color.colorMeasureAggType !== "Custom") {
+    if (groupby.length > 0 && color.colorMeasureAggType !== "Custom") {
       fields.push(colorProjection)
       alias.push("strokeColor")
       ops.push(null)
     } else {
       let expression = null
-      if(color.colorMeasureAggType === "Custom") {
+      if (color.colorMeasureAggType === "Custom") {
         expression = color.field ? color.field : color.aggregate
       } else if (color.type === "quantitative") {
         expression = color.aggregate.field
@@ -150,14 +154,11 @@ function getTransforms(
   if (doJoin()) {
     transforms.push({
       type: "filter",
-      expr: `${state.data[0].table}.${state.data[0].attr} = ${
-        state.data[1].table
-        }.${state.data[1].attr}`
+      expr: `${state.data[0].table}.${state.data[0].attr} = ${state.data[1].table}.${state.data[1].attr}`
     })
   }
 
-
-  if(groupby.length > 0) {
+  if (groupby.length > 0) {
     transforms.push({
       type: "aggregate",
       fields,
@@ -183,7 +184,8 @@ function getTransforms(
   }
 
   if (typeof transform.limit === "number") {
-    if (transform.sample && !doJoin()) { // use Knuth's hash sampling on single data source chart
+    if (transform.sample && !doJoin()) {
+      // use Knuth's hash sampling on single data source chart
       transforms.push({
         type: "sample",
         method: "multiplicative",
@@ -191,7 +193,8 @@ function getTransforms(
         limit: transform.limit,
         sampleTable: geoTable
       })
-    } else { // when geo join is applied, we won't use Knuth's sampling but use LIMIT
+    } else {
+      // when geo join is applied, we won't use Knuth's sampling but use LIMIT
       transforms.push({
         type: "limit",
         row: transform.limit
@@ -256,7 +259,6 @@ export default function rasterLayerLineMixin(_layer) {
   }
 
   function getAutoColorVegaTransforms(data, layerName, statsLayerName) {
-
     const aggregateNode = {
       type: "aggregate",
       fields: [],
@@ -266,14 +268,29 @@ export default function rasterLayerLineMixin(_layer) {
 
     const transforms = [aggregateNode]
     if (state.encoding.color.type === "quantitative") {
-      aggregateNode.fields = aggregateNode.fields.concat(["strokeColor", "strokeColor", "strokeColor", "strokeColor"])
-      aggregateNode.ops = aggregateNode.ops.concat(["min", "max", "avg", "stddev"])
-      aggregateNode.as = aggregateNode.as.concat(["mincol", "maxcol", "avgcol", "stdcol"])
+      aggregateNode.fields = aggregateNode.fields.concat([
+        "strokeColor",
+        "strokeColor",
+        "strokeColor",
+        "strokeColor"
+      ])
+      aggregateNode.ops = aggregateNode.ops.concat([
+        "min",
+        "max",
+        "avg",
+        "stddev"
+      ])
+      aggregateNode.as = aggregateNode.as.concat([
+        "mincol",
+        "maxcol",
+        "avgcol",
+        "stdcol"
+      ])
       transforms.push(
         {
           type: "formula",
           expr: "max(mincol, avgcol-2*stdcol)",
-          as:  "mincolor"
+          as: "mincolor"
         },
         {
           type: "formula",
@@ -281,7 +298,8 @@ export default function rasterLayerLineMixin(_layer) {
           as: "maxcolor"
         }
       )
-    } else if (state.encoding.color.type === "ordinal") { // will be used when we support auto for ordinal color type
+    } else if (state.encoding.color.type === "ordinal") {
+      // will be used when we support auto for ordinal color type
       aggregateNode.fields.push("color")
       aggregateNode.ops.push("distinct")
       aggregateNode.as.push("distinctcolor")
@@ -310,14 +328,14 @@ export default function rasterLayerLineMixin(_layer) {
   }
 
   _layer.__genVega = function({
-                                table,
-                                filter,
-                                lastFilteredSize,
-                                globalFilter,
-                                pixelRatio,
-                                layerName,
-                                useProjection
-                              }) {
+    table,
+    filter,
+    lastFilteredSize,
+    globalFilter,
+    pixelRatio,
+    layerName,
+    useProjection
+  }) {
     const autocolors = usesAutoColors()
     const getStatsLayerName = () => layerName + "_stats"
 
@@ -356,14 +374,20 @@ export default function rasterLayerLineMixin(_layer) {
     if (autocolors) {
       getAutoColorVegaTransforms(data, layerName, getStatsLayerName())
 
-      if(state.encoding.color.type === "quantitative") {
+      if (state.encoding.color.type === "quantitative") {
         scaledomainfields.color = ["mincolor", "maxcolor"]
-      } else if(state.encoding.color.type === "ordinal") { // will be used when we support auto for ordinal color type
+      } else if (state.encoding.color.type === "ordinal") {
+        // will be used when we support auto for ordinal color type
         scaledomainfields.color = ["distinctcolor"]
       }
     }
 
-    const scales = getScales(state.encoding, layerName, scaledomainfields, getStatsLayerName())
+    const scales = getScales(
+      state.encoding,
+      layerName,
+      scaledomainfields,
+      getStatsLayerName()
+    )
 
     const marks = [
       {
@@ -426,14 +450,15 @@ export default function rasterLayerLineMixin(_layer) {
   }
 
   _layer._genVega = function(chart, layerName, group, query) {
-
     // needed to set LastFilteredSize when linemap map first initialized
-    if (
-      _layer.viewBoxDim()
-    ) {
-      _layer.viewBoxDim().groupAll().valueAsync().then(value => {
-        setLastFilteredSize(_layer.crossfilter().getId(), value)
-      })
+    if (_layer.viewBoxDim()) {
+      _layer
+        .viewBoxDim()
+        .groupAll()
+        .valueAsync()
+        .then(value => {
+          setLastFilteredSize(_layer.crossfilter().getId(), value)
+        })
     }
 
     _vega = _layer.__genVega({
@@ -448,7 +473,6 @@ export default function rasterLayerLineMixin(_layer) {
 
     return _vega
   }
-
 
   _layer._addRenderAttrsToPopupColumnSet = function(chart, popupColsSet) {
     // add the poly geometry to the query
@@ -485,7 +509,7 @@ export default function rasterLayerLineMixin(_layer) {
   }
 
   _layer._displayPopup = function(svgProps) {
-    return __displayPopup({ ...svgProps, _vega, _layer, state})
+    return __displayPopup({ ...svgProps, _vega, _layer, state })
   }
 
   const _scaledPopups = {}

--- a/src/mixins/raster-layer-point-mixin.js
+++ b/src/mixins/raster-layer-point-mixin.js
@@ -10,7 +10,7 @@ import {
 } from "../utils/utils-vega"
 import { parser } from "../utils/utils"
 import * as d3 from "d3"
-import {AABox2d, Point2d} from "@mapd/mapd-draw/dist/mapd-draw"
+import { AABox2d, Point2d } from "@mapd/mapd-draw/dist/mapd-draw"
 
 const AUTOSIZE_DOMAIN_DEFAULTS = [100000, 0]
 const AUTOSIZE_RANGE_DEFAULTS = [2.0, 5.0]
@@ -97,28 +97,36 @@ function getColor(color, layerName) {
 }
 
 function isValidPostFilter(postFilter) {
-  const {
-    operator,
-    min,
-    max,
-    aggType,
-    value,
-    custom
-  } = postFilter
+  const { operator, min, max, aggType, value, custom } = postFilter
 
   if (value && (aggType || custom)) {
-    if ((operator === "not between" || operator === "between") && (typeof min === "number" && !isNaN(min)) && (typeof max === "number" && !isNaN(max))) {
+    if (
+      (operator === "not between" || operator === "between") &&
+      (typeof min === "number" && !isNaN(min)) &&
+      (typeof max === "number" && !isNaN(max))
+    ) {
       return true
-    } else if ((operator === "equals" || operator === "not equals" || operator === "greater than or equals") && (typeof min === "number" && !isNaN(min))) {
+    } else if (
+      (operator === "equals" ||
+        operator === "not equals" ||
+        operator === "greater than or equals") &&
+      (typeof min === "number" && !isNaN(min))
+    ) {
       return true
-    } else if (operator === "less than or equals" && typeof max === "number" && !isNaN(max)) {
+    } else if (
+      operator === "less than or equals" &&
+      typeof max === "number" &&
+      !isNaN(max)
+    ) {
       return true
     } else if (operator === "null" || operator === "not null") {
       return true
     } else {
       return false
     }
-  } else { return false}
+  } else {
+    return false
+  }
 }
 
 function getTransforms(
@@ -292,24 +300,40 @@ export default function rasterLayerPointMixin(_layer) {
   }
 
   function getAutoColorVegaTransforms(aggregateNode) {
-    const rtnobj = {transforms: [], fields: []}
+    const rtnobj = { transforms: [], fields: [] }
     if (state.encoding.color.type === "quantitative") {
-      const minoutput = "mincolor", maxoutput = "maxcolor"
-      aggregateNode.fields = aggregateNode.fields.concat(["color", "color", "color", "color"])
-      aggregateNode.ops = aggregateNode.ops.concat(["min", "max", "avg", "stddev"])
-      aggregateNode.as = aggregateNode.as.concat(["mincol", "maxcol", "avgcol", "stdcol"])
+      const minoutput = "mincolor",
+        maxoutput = "maxcolor"
+      aggregateNode.fields = aggregateNode.fields.concat([
+        "color",
+        "color",
+        "color",
+        "color"
+      ])
+      aggregateNode.ops = aggregateNode.ops.concat([
+        "min",
+        "max",
+        "avg",
+        "stddev"
+      ])
+      aggregateNode.as = aggregateNode.as.concat([
+        "mincol",
+        "maxcol",
+        "avgcol",
+        "stdcol"
+      ])
       rtnobj.transforms.push(
-          {
-            type: "formula",
-            expr: "max(mincol, avgcol-2*stdcol)",
-            as: minoutput
-          },
-          {
-            type: "formula",
-            expr: "min(maxcol, avgcol+2*stdcol)",
-            as: maxoutput
-          }
-        )
+        {
+          type: "formula",
+          expr: "max(mincol, avgcol-2*stdcol)",
+          as: minoutput
+        },
+        {
+          type: "formula",
+          expr: "min(maxcol, avgcol+2*stdcol)",
+          as: maxoutput
+        }
+      )
       rtnobj.fields = [minoutput, maxoutput]
     } else if (state.encoding.color.type === "ordinal") {
       const output = "distinctcolor"
@@ -322,7 +346,8 @@ export default function rasterLayerPointMixin(_layer) {
   }
 
   function getAutoSizeVegaTransforms(aggregateNode) {
-    const minoutput = "minsize", maxoutput = "maxsize"
+    const minoutput = "minsize",
+      maxoutput = "maxsize"
     aggregateNode.fields.push("size", "size", "size", "size")
     aggregateNode.ops.push("min", "max", "avg", "stddev")
     aggregateNode.as.push("minsz", "maxsz", "avgsz", "stdsz")
@@ -426,7 +451,12 @@ export default function rasterLayerPointMixin(_layer) {
       })
     }
 
-    const scales = getScales(state.encoding, layerName, scaledomainfields, getStatsLayerName())
+    const scales = getScales(
+      state.encoding,
+      layerName,
+      scaledomainfields,
+      getStatsLayerName()
+    )
 
     const marks = [
       {
@@ -527,14 +557,15 @@ export default function rasterLayerPointMixin(_layer) {
   }
 
   _layer._genVega = function(chart, layerName, group, query) {
-
     // needed to set LastFilteredSize when point map first initialized
-    if (
-      _layer.yDim()
-    ) {
-      _layer.yDim().groupAll().valueAsync().then(value => {
-        setLastFilteredSize(_layer.crossfilter().getId(), value)
-      })
+    if (_layer.yDim()) {
+      _layer
+        .yDim()
+        .groupAll()
+        .valueAsync()
+        .then(value => {
+          setLastFilteredSize(_layer.crossfilter().getId(), value)
+        })
     }
 
     _vega = _layer.__genVega({
@@ -549,13 +580,7 @@ export default function rasterLayerPointMixin(_layer) {
     return _vega
   }
 
-  const renderAttributes = [
-    "xc",
-    "yc",
-    "width",
-    "height",
-    "fillColor"
-  ]
+  const renderAttributes = ["xc", "yc", "width", "height", "fillColor"]
 
   _layer._addRenderAttrsToPopupColumnSet = function(chart, popupColumnsSet) {
     if (
@@ -614,8 +639,10 @@ export default function rasterLayerPointMixin(_layer) {
       })
     }
 
-    const pixel = Point2d.create(xscale(data[rndrProps.xc || rndrProps.x]) + margins.left,
-                                 height - yscale(data[rndrProps.yc || rndrProps.y]) + margins.top)
+    const pixel = Point2d.create(
+      xscale(data[rndrProps.xc || rndrProps.x]) + margins.left,
+      height - yscale(data[rndrProps.yc || rndrProps.y]) + margins.top
+    )
 
     let sizeFromData =
       data[rndrProps.size || rndrProps.width || rndrProps.height]
@@ -671,7 +698,10 @@ export default function rasterLayerPointMixin(_layer) {
       gfxDiv.style("border-width", strokeWidth)
     }
 
-    return AABox2d.initCenterExtents(AABox2d.create(), pixel, [dotSize / 2, dotSize / 2])
+    return AABox2d.initCenterExtents(AABox2d.create(), pixel, [
+      dotSize / 2,
+      dotSize / 2
+    ])
   }
 
   _layer._hidePopup = function(chart, hideCallback) {

--- a/src/mixins/raster-layer-poly-mixin.unit.spec.js
+++ b/src/mixins/raster-layer-poly-mixin.unit.spec.js
@@ -395,7 +395,8 @@ describe("rasterLayerPolyMixin", () => {
           {
             name: "polys",
             format: "polys",
-            sql: "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)",
+            sql:
+              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)",
             enableHitTesting: false
           },
           {

--- a/src/mixins/raster-layer.js
+++ b/src/mixins/raster-layer.js
@@ -7,7 +7,7 @@ import {
   createRasterLayerGetterSetter,
   createVegaAttrMixin
 } from "../utils/utils-vega"
-import {AABox2d, Point2d} from "@mapd/mapd-draw/dist/mapd-draw"
+import { AABox2d, Point2d } from "@mapd/mapd-draw/dist/mapd-draw"
 
 const validLayerTypes = ["points", "polys", "heat", "lines"]
 
@@ -224,9 +224,17 @@ export default function rasterLayer(layerType) {
     // data structure, but probably not an issue given the amount
     // of popup col attrs to iterate through is small
     const dim = _layer.group() || _layer.dimension()
-    if (dim || (_layer.layerType() === "points" || _layer.layerType() === "lines" || _layer.layerType() === "polys")) {
+    if (
+      dim ||
+      (_layer.layerType() === "points" ||
+        _layer.layerType() === "lines" ||
+        _layer.layerType() === "polys")
+    ) {
       const projExprs =
-        _layer.layerType() === "points" || _layer.layerType() === "lines" ||  _layer.layerType() === "polys" ||  _layer.layerType() === ""
+        _layer.layerType() === "points" ||
+        _layer.layerType() === "lines" ||
+        _layer.layerType() === "polys" ||
+        _layer.layerType() === ""
           ? _layer.getProjections()
           : dim.getProjectOn(true) // handles the group and dimension case
       const regex = /^\s*(\S+)\s+as\s+(\S+)/i
@@ -304,7 +312,7 @@ export default function rasterLayer(layerType) {
         return
       }
 
-      const columnKey = (columnMap && columnMap[key]) ? columnMap[key] : key
+      const columnKey = columnMap && columnMap[key] ? columnMap[key] : key
       const columnKeyTrimmed = columnKey.replace(/.*\((.*)\).*/, "$1")
 
       html =
@@ -358,7 +366,8 @@ export default function rasterLayer(layerType) {
     xscale.range([0, width])
     yscale.range([0, height])
 
-    const hoverSvgProps = {chart,
+    const hoverSvgProps = {
+      chart,
       parentElem,
       data,
       width,
@@ -367,7 +376,8 @@ export default function rasterLayer(layerType) {
       xscale,
       yscale,
       minPopupArea,
-      animate}
+      animate
+    }
 
     const bounds = _layer._displayPopup(hoverSvgProps)
 
@@ -404,7 +414,12 @@ export default function rasterLayer(layerType) {
       .html(
         _layer.popupFunction()
           ? _layer.popupFunction(filteredData, popupColumns, mappedColumns)
-          : renderPopupHTML(filteredData, popupColumns, mappedColumns, chart.measureValue)
+          : renderPopupHTML(
+              filteredData,
+              popupColumns,
+              mappedColumns,
+              chart.measureValue
+            )
       )
       .style("left", function() {
         const rect = d3
@@ -423,7 +438,8 @@ export default function rasterLayer(layerType) {
 
         if (
           overlapSz[0] >= boxWidth ||
-          (boundsCtr[0] + halfBoxWidth < width && boundsCtr[0] - halfBoxWidth >= 0)
+          (boundsCtr[0] + halfBoxWidth < width &&
+            boundsCtr[0] - halfBoxWidth >= 0)
         ) {
           left = boundsCtr[0] - overlapCtr[0]
           hDiff = overlapBounds[AABox2d.MINY] - boxHeight
@@ -443,14 +459,18 @@ export default function rasterLayer(layerType) {
           if (hDiff < height) {
             // can fit on bottom and in the center of the shape horizontally
             topOffset =
-              overlapBounds[AABox2d.MAXY] - boundsCtr[1] + Math.min(padding, hDiff) + halfBoxHeight
+              overlapBounds[AABox2d.MAXY] -
+              boundsCtr[1] +
+              Math.min(padding, hDiff) +
+              halfBoxHeight
             return left + "px"
           }
         }
 
         if (
           overlapSz[1] >= boxHeight ||
-          (boundsCtr[1] + halfBoxHeight < height && boundsCtr[1] - halfBoxHeight >= 0)
+          (boundsCtr[1] + halfBoxHeight < height &&
+            boundsCtr[1] - halfBoxHeight >= 0)
         ) {
           topOffset = overlapCtr[1] - boundsCtr[1]
 
@@ -470,7 +490,10 @@ export default function rasterLayer(layerType) {
           if (wDiff < width) {
             // can fit on right in the center of the shape vertically
             left =
-              overlapBounds[AABox2d.MAXX] - boundsCtr[0] + Math.min(padding, wDiff) + halfBoxWidth
+              overlapBounds[AABox2d.MAXX] -
+              boundsCtr[0] +
+              Math.min(padding, wDiff) +
+              halfBoxWidth
             return left + "px"
           }
         }
@@ -486,8 +509,12 @@ export default function rasterLayer(layerType) {
             Math.abs(boxWidth - overlapSz[0])
           ) {
             hDiff = height - overlapSz[1] - boxHeight
-            if (overlapBounds[AABox2d.MINY] < height - overlapBounds[AABox2d.MAXY]) {
-              topOffset = Math.min(padding, hDiff) + halfBoxHeight - boundsCtr[1]
+            if (
+              overlapBounds[AABox2d.MINY] <
+              height - overlapBounds[AABox2d.MAXY]
+            ) {
+              topOffset =
+                Math.min(padding, hDiff) + halfBoxHeight - boundsCtr[1]
             } else {
               topOffset =
                 height - Math.min(padding, hDiff) - halfBoxHeight - boundsCtr[1]
@@ -514,10 +541,14 @@ export default function rasterLayer(layerType) {
             return left + "px"
           } else {
             wDiff = width - overlapSz[0] - boxWidth
-            if (overlapBounds[AABox2d.MINX] < width - overlapBounds[AABox2d.MAXX]) {
+            if (
+              overlapBounds[AABox2d.MINX] <
+              width - overlapBounds[AABox2d.MAXX]
+            ) {
               left = Math.min(padding, wDiff) + halfBoxWidth - boundsCtr[0]
             } else {
-              left = width - Math.min(padding, wDiff) - halfBoxWidth - boundsCtr[0]
+              left =
+                width - Math.min(padding, wDiff) - halfBoxWidth - boundsCtr[0]
             }
 
             hDiff = overlapBounds[AABox2d.MINY] - boxHeight

--- a/src/mixins/ui/lasso-tool-ui.js
+++ b/src/mixins/ui/lasso-tool-ui.js
@@ -53,7 +53,7 @@ export function getLatLonCircleClass() {
           this._mercatorPts = []
           for (let index = 0; index < number_of_points; index = index + 1) {
             const degrees = index * degrees_between_points
-            const degree_radians = degrees * Math.PI / 180
+            const degree_radians = (degrees * Math.PI) / 180
             const point_lat_radians = Math.asin(
               Math.sin(center_lat_radians) * Math.cos(dist_radians) +
                 Math.cos(center_lat_radians) *
@@ -69,8 +69,8 @@ export function getLatLonCircleClass() {
                 Math.cos(dist_radians) -
                   Math.sin(center_lat_radians) * Math.sin(point_lat_radians)
               )
-            const point_lat = point_lat_radians * 180 / Math.PI
-            const point_lon = point_lon_radians * 180 / Math.PI
+            const point_lat = (point_lat_radians * 180) / Math.PI
+            const point_lon = (point_lon_radians * 180) / Math.PI
             const point = MapdDraw.Point2d.create(point_lon, point_lat)
 
             // convert from lon/lat to mercator

--- a/src/utils/formatting-helpers.js
+++ b/src/utils/formatting-helpers.js
@@ -12,9 +12,15 @@ export const momentUTCFormat = (d, f) =>
     .format(f)
 export const genericDateTimeFormat = d => {
   if (d.getMilliseconds() === 0) {
-    return `${momentUTCFormat(d, "MMM D, YYYY")} \u205F${momentUTCFormat(d,"HH:mm:ss")}`
+    return `${momentUTCFormat(d, "MMM D, YYYY")} \u205F${momentUTCFormat(
+      d,
+      "HH:mm:ss"
+    )}`
   }
-  return `${momentUTCFormat(d, "MMM D, YYYY")} \u205F${momentUTCFormat(d,"HH:mm:ss.SSS")}`
+  return `${momentUTCFormat(d, "MMM D, YYYY")} \u205F${momentUTCFormat(
+    d,
+    "HH:mm:ss.SSS"
+  )}`
 }
 export const isPlainObject = value =>
   !Array.isArray(value) && typeof value === "object" && !(value instanceof Date)

--- a/src/utils/formatting-helpers.unit.spec.js
+++ b/src/utils/formatting-helpers.unit.spec.js
@@ -243,7 +243,7 @@ describe("Formatting Helpers", () => {
   })
 
   describe("format cache helper", () => {
-    const AxisMock = function () {
+    const AxisMock = function() {
       let cachedFormat = d => d + "foo"
       return {
         tickFormat: d => {
@@ -265,6 +265,5 @@ describe("Formatting Helpers", () => {
       formatCache.setTickFormatFromCache()
       expect(axisMock.tickFormat()("a")).to.equal("afoo")
     })
-
   })
 })

--- a/src/utils/utils-vega.js
+++ b/src/utils/utils-vega.js
@@ -1,6 +1,6 @@
 import d3 from "d3"
-import wellknown from "wellknown";
-import {AABox2d, Point2d, PolyLine} from "@mapd/mapd-draw/dist/mapd-draw";
+import wellknown from "wellknown"
+import { AABox2d, Point2d, PolyLine } from "@mapd/mapd-draw/dist/mapd-draw"
 export function notNull(value) {
   return value != null /* double-equals also catches undefined */
 }
@@ -109,7 +109,9 @@ export function createVegaAttrMixin(
         const colorScaleName = layerName + "_" + attrName,
           colorsToUse = layerObj.defaultFillColor(),
           domainInterval = 100 / (colorsToUse.length - 1),
-          linearColorScale = colorsToUse.map((color, i) => i * domainInterval / 100),
+          linearColorScale = colorsToUse.map(
+            (color, i) => (i * domainInterval) / 100
+          ),
           range = colorsToUse.map((color, i, colorArray) => {
             const normVal = i / (colorArray.length - 1)
             let interp = Math.min(normVal / 0.65, 1.0)
@@ -151,15 +153,23 @@ export function createVegaAttrMixin(
         if (domainVals === "auto") {
           const domainGetterFunc = encodingAttrName + "Domain"
           if (typeof layerObj[domainGetterFunc] !== "function") {
-            throw new Error(`Looking for a ${domainGetterFunc} function on for attr ${attrName}`)
+            throw new Error(
+              `Looking for a ${domainGetterFunc} function on for attr ${attrName}`
+            )
           }
           domainVals = layerObj[domainGetterFunc]()
         }
         if (capAttrObj.type === "ordinal") {
           ordScale.domain(domainVals).range(capAttrObj.range)
           // if color range is not in domain, it's an Other item
-          rtnVal = domainVals.indexOf(input) === -1 ? ordScale("Other") : ordScale(input)
-        } else if (Array.isArray(domainVals) && domainVals[0] === domainVals[1]) {
+          rtnVal =
+            domainVals.indexOf(input) === -1
+              ? ordScale("Other")
+              : ordScale(input)
+        } else if (
+          Array.isArray(domainVals) &&
+          domainVals[0] === domainVals[1]
+        ) {
           // handling case where domain min/max are the same (FE-7408)
           linearScale.domain(domainVals).range(capAttrObj.range)
           rtnVal = Math.round(linearScale(input))
@@ -200,7 +210,6 @@ export function createRasterLayerGetterSetter(
     return layerObj
   }
 }
-
 
 // Polygon and line svg on hovering
 
@@ -358,11 +367,11 @@ function buildGeoProjection(
       const pt = [
         _scale * (xscale(projectedCoord[0]) + margins.left - _translation[0]),
         _scale *
-        (height -
-          yscale(projectedCoord[1]) -
-          1 +
-          margins.top -
-          _translation[1])
+          (height -
+            yscale(projectedCoord[1]) -
+            1 +
+            margins.top -
+            _translation[1])
       ]
       if (_clamp) {
         if (pt[0] >= 0 && pt[0] < width && pt[1] >= 0 && pt[1] < height) {
@@ -401,7 +410,7 @@ export class GeoSvgFormatter extends SvgFormatter {
       throw new Error(
         `Cannot create SVG from geo polygon column "${
           this._geocol
-          }". The data returned is not a WKT string. It is of type: ${typeof wkt}`
+        }". The data returned is not a WKT string. It is of type: ${typeof wkt}`
       )
     }
     this._geojson = wellknown.parse(wkt)
@@ -450,18 +459,18 @@ const _scaledPopups = {}
 export function __displayPopup(svgProps) {
   const {
     chart,
-      parentElem,
-      data,
-      width,
-      height,
-      margins,
-      xscale,
-      yscale,
-      minPopupArea,
-      animate,
-      _vega,
-      _layer,
-      state
+    parentElem,
+    data,
+    width,
+    height,
+    margins,
+    xscale,
+    yscale,
+    minPopupArea,
+    animate,
+    _vega,
+    _layer,
+    state
   } = svgProps
 
   const layerType = _layer.layerType()
@@ -477,9 +486,7 @@ export function __displayPopup(svgProps) {
   } else if (!chart._useGeoTypes && layerType === "polys") {
     geoPathFormatter = new LegacyPolySvgFormatter()
   } else {
-    throw new Error(
-      "Cannot build outline popup."
-    )
+    throw new Error("Cannot build outline popup.")
   }
 
   const bounds = geoPathFormatter.getBounds(
@@ -568,11 +575,11 @@ export function __displayPopup(svgProps) {
     .attr(
       "transform",
       "translate(" +
-      (scale * bounds[AABox2d.MINX] - (scale - 1) * boundsCtr[0]) +
-      ", " +
-      (scale * (bounds[AABox2d.MINY] + 1) -
-        (scale - 1) * (boundsCtr[1] + 1)) +
-      ")"
+        (scale * bounds[AABox2d.MINX] - (scale - 1) * boundsCtr[0]) +
+        ", " +
+        (scale * (bounds[AABox2d.MINY] + 1) -
+          (scale - 1) * (boundsCtr[1] + 1)) +
+        ")"
     )
 
   // now add a transform node that will be used to apply animated scales to
@@ -597,29 +604,31 @@ export function __displayPopup(svgProps) {
     group.style("stroke-width", strokeWidth)
   }
 
-  if(layerType === "lines") {
+  if (layerType === "lines") {
     // applying shadow
-    const defs = group
-    .append('defs')
+    const defs = group.append("defs")
 
-    const filter = defs.append("filter")
+    const filter = defs
+      .append("filter")
       .attr("id", "drop-shadow")
       .attr("width", "200%")
-      .attr("height", "200%");
+      .attr("height", "200%")
 
-    filter.append("feOffset")
+    filter
+      .append("feOffset")
       .attr("in", "SourceAlpha")
       .attr("result", "offOut")
       .attr("dx", "2")
-      .attr("dy", "2");
+      .attr("dy", "2")
 
-    filter.append("feGaussianBlur")
+    filter
+      .append("feGaussianBlur")
       .attr("in", "offOut")
       .attr("stdDeviation", 2)
-      .attr("result", "blurOut");
+      .attr("result", "blurOut")
 
-
-    filter.append("feBlend")
+    filter
+      .append("feBlend")
       .attr("in", "SourceGraphic")
       .attr("in2", "blurOut")
       .attr("mode", "normal")
@@ -634,19 +643,19 @@ export function __displayPopup(svgProps) {
         scale
       )
     )
-    .attr("class", layerType === "polys" ? "map-polygon-shape": "map-polyline")
+    .attr("class", layerType === "polys" ? "map-polygon-shape" : "map-polyline")
     .attr("fill", layerType === "polys" ? fillColor : "none")
     .attr("fill-rule", "evenodd")
     .attr("stroke-width", strokeWidth)
     .attr("stroke", strokeColor)
     .style("filter", layerType === "polys" ? "none" : "url(#drop-shadow)")
     .on("click", () => {
-      if(layerType === "polys") {
+      if (layerType === "polys") {
         return _layer.onClick(chart, data, d3.event)
       } else {
         return null
       }
-     })
+    })
 
   _scaledPopups[chart] = isScaled
 
@@ -654,7 +663,7 @@ export function __displayPopup(svgProps) {
 }
 
 export function getSizeScaleName(layerName) {
-  if(layerName === "linemap") {
+  if (layerName === "linemap") {
     return `${layerName}_strokeWidth`
   } else {
     return `${layerName}_size`
@@ -662,22 +671,32 @@ export function getSizeScaleName(layerName) {
 }
 
 export function getColorScaleName(layerName) {
-  if(layerName === "linemap") {
+  if (layerName === "linemap") {
     return `${layerName}_strokeColor`
   } else {
     return `${layerName}_fillColor`
   }
 }
 
-
-export function getScales({ size, color }, layerName, scaleDomainFields, xformDataSource) {
+export function getScales(
+  { size, color },
+  layerName,
+  scaleDomainFields,
+  xformDataSource
+) {
   const scales = []
 
-  if (typeof size === "object" && (size.type === "quantitative" || size.type === "custom")) {
+  if (
+    typeof size === "object" &&
+    (size.type === "quantitative" || size.type === "custom")
+  ) {
     scales.push({
       name: getSizeScaleName(layerName),
       type: "linear",
-      domain: (size.domain === "auto" ? {data: xformDataSource, fields: scaleDomainFields.size} : size.domain),
+      domain:
+        size.domain === "auto"
+          ? { data: xformDataSource, fields: scaleDomainFields.size }
+          : size.domain,
       range: size.range,
       clamp: true
     })
@@ -688,7 +707,7 @@ export function getScales({ size, color }, layerName, scaleDomainFields, xformDa
       name: getColorScaleName(layerName),
       type: "linear",
       domain: color.range.map(
-        (c, i) => i * 100 / (color.range.length - 1) / 100
+        (c, i) => (i * 100) / (color.range.length - 1) / 100
       ),
       range: color.range
         .map(c => adjustOpacity(c, color.opacity))
@@ -709,7 +728,10 @@ export function getScales({ size, color }, layerName, scaleDomainFields, xformDa
     scales.push({
       name: getColorScaleName(layerName),
       type: "ordinal",
-      domain: (color.domain === "auto" ? {data: xformDataSource, fields: scaleDomainFields.color} : color.domain),
+      domain:
+        color.domain === "auto"
+          ? { data: xformDataSource, fields: scaleDomainFields.color }
+          : color.domain,
       range: color.range.map(c => adjustOpacity(c, color.opacity)),
       default: adjustOpacity(
         color.range[color.range.length - 1], // in current implementation 'Other' is always added as last element in the array
@@ -723,7 +745,10 @@ export function getScales({ size, color }, layerName, scaleDomainFields, xformDa
     scales.push({
       name: getColorScaleName(layerName),
       type: "quantize",
-      domain: (color.domain === "auto" ? {data: xformDataSource, fields: scaleDomainFields.color} : color.domain),
+      domain:
+        color.domain === "auto"
+          ? { data: xformDataSource, fields: scaleDomainFields.color }
+          : color.domain,
       range: color.range.map(c => adjustOpacity(c, color.opacity))
     })
   }


### PR DESCRIPTION
The mapd-charting repo already has a formatter and formatting rules configured for it. However, since the developer must manually run `npm run format`, and this is rarely done, a substantial portion of the files in the repo have incorrect formatting.

The acceptance criteria for this ticket are two-fold:

1. Run `npm run format` on the entire mapd-charting repo to ensure all files are correctly formatted.
2. Add a "check formatting" step to the test suite (i.e. `npm run test` command) so that formatting problems will cause a test failure, and block the PR containing them from being merged.

**Note**: this diff is huge because people haven't run `prettier` in forever, so nearly every file had a change. These should be 100% formatting changes, though, and not change functionality.

Also note to future `git blame` users who have traced back the entire codebase to this PR: I'm sorry, and this isn't the diff you are looking for.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Fixes FE-8955

## :smoking: Smoke Test
- [x] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
