### PR TITLE
[FE-9007] Handle invalid Date objects in `compareDomains()`

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -9125,8 +9125,11 @@ function coordinateGridMixin(_chart) {
 
   function compareDomains(d1, d2) {
     return !d1 || !d2 || d1.length !== d2.length || d1.some(function (elem, i) {
-      var elemString = elem instanceof Date ? elem.toISOString() : elem.toString();
-      var d2String = d2[i] instanceof Date ? d2[i].toISOString() : d2[i].toString();
+      // The date objects here may be invalid for some reason. We detect that by ensuring
+      // getTime() doesn't return NaN. If invalid, we use toString() instead of toISOString,
+      // since the former doesn't throw an exception with invalid dates.
+      var elemString = elem instanceof Date && !isNaN(elem.getTime()) ? elem.toISOString() : elem.toString();
+      var d2String = d2[i] instanceof Date && !isNaN(d2[i].getTime()) ? d2[i].toISOString() : d2[i].toString();
       return elem && d2[i] ? elemString !== d2String : elem === d2[i];
     });
   }
@@ -11226,7 +11229,7 @@ function getScales(_ref, layerName, scaleDomainFields, xformDataSource) {
   var undefined;
 
   /** Used as the semantic version number. */
-  var VERSION = '4.17.14';
+  var VERSION = '4.17.15';
 
   /** Used as the size to enable large array optimizations. */
   var LARGE_ARRAY_SIZE = 200;

--- a/package-lock.json
+++ b/package-lock.json
@@ -4919,7 +4919,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4940,12 +4941,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4960,17 +4963,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5087,7 +5093,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5099,6 +5106,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5113,6 +5121,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5120,12 +5129,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5144,6 +5155,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5231,7 +5243,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5243,6 +5256,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5328,7 +5342,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5364,6 +5379,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5383,6 +5399,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5426,12 +5443,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8824,6 +8843,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9573,7 +9593,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/src/mixins/coordinate-grid-mixin.js
+++ b/src/mixins/coordinate-grid-mixin.js
@@ -504,8 +504,11 @@ export default function coordinateGridMixin (_chart) {
     return (
       !d1 || !d2 || d1.length !== d2.length || d1.some(
         (elem, i) => {
-          const elemString = elem instanceof Date ? elem.toISOString() : elem.toString()
-          const d2String = d2[i] instanceof Date ? d2[i].toISOString() : d2[i].toString()
+          // The date objects here may be invalid for some reason. We detect that by ensuring
+          // getTime() doesn't return NaN. If invalid, we use toString() instead of toISOString,
+          // since the former doesn't throw an exception with invalid dates.
+          const elemString = elem instanceof Date && !isNaN(elem.getTime()) ? elem.toISOString() : elem.toString()
+          const d2String = d2[i] instanceof Date && !isNaN(d2[i].getTime()) ? d2[i].toISOString() : d2[i].toString()
           return elem && d2[i] ? elemString !== d2String : elem === d2[i]
         }
       )


### PR DESCRIPTION
In certain circumstances (like creating a date global filter, and just clicking inside the start/end time inputs without changing them), the Date objects in `d2` (the second domain array) are invalid. Like, they're Date objects, but were created with invalid values. I'm not sure how or why these invalid Date objects are being created, but nonetheless, calling `toISOString()` on them throws an exception.

Due to JavaScript being JavaScript, calling `toString()` does not throw an exception; it just returns the string "Invalid date". So in `compareDomains()`, we test if the Date is valid (by checking `getTime()` doesn't return NaN). If it's valid, we call `toISOString()` like normal; if it's invalid, we just call `toString()` to avoid the exception.

This bug was introduced by PR #370 (FE-8934), which changed `toString()` to `toISOString()` in `compareDomains()`.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Fixes FE-9007

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
