### PR TITLE
[FE-9568] reapply bbox filter when poly filter removed from new filter panel

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -54859,9 +54859,9 @@ function rasterLayerPolyMixin(_layer) {
   var polyLayerEvents = ["filtered"];
   var _listeners = _d2.default.dispatch.apply(_d2.default, polyLayerEvents);
 
-  _layer.filter = function (key, isInverseFilter, filterCol) {
+  _layer.filter = function (key, isInverseFilter, filterCol, chart) {
     if (isInverseFilter !== _layer.filtersInverse()) {
-      _layer.filterAll();
+      _layer.filterAll(chart);
       _layer.filtersInverse(isInverseFilter);
     }
     if (_filtersArray.includes(key)) {
@@ -54884,21 +54884,30 @@ function rasterLayerPolyMixin(_layer) {
       _layer.viewBoxDim(null);
     }
 
-    _filtersArray.length && filterCol ? _layer.dimension().filterMulti(_filtersArray, undefined, isInverseFilter) : _layer.filterAll();
+    _filtersArray.length && filterCol ? _layer.dimension().filterMulti(_filtersArray, undefined, isInverseFilter) : _layer.filterAll(chart);
   };
 
   _layer.filters = function () {
     return _filtersArray;
   };
 
-  _layer.filterAll = function () {
+  _layer.filterAll = function (chart) {
     _filtersArray = [];
     _layer.dimension().filterAll();
     var geoCol = _layer.getState().encoding.geoTable + "." + _layer.getState().encoding.geocol;
+
+    // when poly selection filter cleared, we reapply the bbox filter
     var viewboxdim = _layer.dimension().set(function () {
       return [geoCol];
     });
+    var mapBounds = chart.map().getBounds();
     _layer.viewBoxDim(viewboxdim);
+    _layer.viewBoxDim().filterST_Min_ST_Max({
+      lonMin: mapBounds._sw.lng,
+      lonMax: mapBounds._ne.lng,
+      latMin: mapBounds._sw.lat,
+      latMax: mapBounds._ne.lat
+    });
     _listeners.filtered(_layer, _filtersArray);
   };
 
@@ -77757,7 +77766,7 @@ function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
     for (var layerName in _layerNames) {
       var _layer4 = _layerNames[layerName];
       if (typeof _layer4.filterAll === "function") {
-        _layer4.filterAll();
+        _layer4.filterAll(_chart);
       }
     }
   };

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -203,7 +203,7 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
     for (const layerName in _layerNames) {
       const layer = _layerNames[layerName]
       if (typeof layer.filterAll === "function") {
-        layer.filterAll()
+        layer.filterAll(_chart)
       }
     }
   }


### PR DESCRIPTION
# Merge Checklist
Create a NON geo joined Choropleth chart, then click on a polygon to filter. Go to the Dashboard view and open the new filter panel. Click x button to clear the rowid="" filter which is the polygon selection filter. We should see all polys without any filter and bbox reappearing on the new filter panel instead of the rowid="" filter.

## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #https://jira.omnisci.com/browse/FE-9568

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
