### PR TITLE
fix issue with number charts not updating

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -77473,21 +77473,6 @@ function numberChart(parent, chartGroup) {
 
   _chart.setDataAsync(function (group, callbacks) {
     return group.valueAsync().then(function (data) {
-      if (group.getReduceExpression() === "COUNT(*) AS val") {
-        var id = group.getCrossfilterId();
-        var filterSize = (0, _coreAsync.lastFilteredSize)(id);
-        if (filterSize !== undefined) {
-          return Promise.resolve(filterSize);
-        } else {
-          return _chart.dimension().sizeAsync().then(group.valueAsync).then(function (value) {
-            (0, _coreAsync.setLastFilteredSize)(id, value);
-            return value;
-          });
-        }
-      } else {
-        return data;
-      }
-    }).then(function (data) {
       callbacks(null, data);
     }).catch(function (error) {
       callbacks(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -5057,7 +5057,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5078,12 +5079,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5098,17 +5101,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5225,7 +5231,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5237,6 +5244,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5251,6 +5259,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5258,12 +5267,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5282,6 +5293,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5369,7 +5381,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5381,6 +5394,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5466,7 +5480,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5502,6 +5517,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5521,6 +5537,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5564,12 +5581,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -8861,6 +8880,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -9610,7 +9630,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",

--- a/src/charts/number-chart.js
+++ b/src/charts/number-chart.js
@@ -25,26 +25,6 @@ export default function numberChart(parent, chartGroup) {
     group
       .valueAsync()
       .then(data => {
-        if (group.getReduceExpression() === "COUNT(*) AS val") {
-          const id = group.getCrossfilterId()
-          const filterSize = lastFilteredSize(id)
-          if (filterSize !== undefined) {
-            return Promise.resolve(filterSize)
-          } else {
-            return _chart
-              .dimension()
-              .sizeAsync()
-              .then(group.valueAsync)
-              .then(value => {
-                setLastFilteredSize(id, value)
-                return value
-              })
-          }
-        } else {
-          return data
-        }
-      })
-      .then(data => {
         callbacks(null, data)
       })
       .catch(error => {


### PR DESCRIPTION
It seems the intention of this code is to use a cached value if the number chart is showing a count. However, this cache is only updated by the count widget, and only one count widget appears on the page when the dashboard loads. So, if this number chart _happens_ to have the same datasource as the count widget that shows up beneath the dashboard name, then it works. Otherwise, the cache is never updated, so the number chart never updates.

To make matters worse, by the time this code runs, a query has already executed to get a count. So, in the best case scenario where this chart's datasource matches the count widget's datasource, it's _still_ running a query twice. In the worst case scenario where the datasources don't match, the query runs, gets the correct value, then throws it away in favor of the stale cached value. Oops!

# Merge Checklist
## :wrench: Issue(s) fixed:
- [x] Author referenced issue(s) fixed by this PR:
- [x] Fixes FE-9601

## :smoking: Smoke Test
- [ ] Works in chrome
- [x] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [x] author crafted PR's title into release-worthy commit message.
