### PR TITLE
Remove .only() from parseFactsFromCustomSQL test and fix tests

### DIFF
--- a/src/chart-addons/dc-legend-cont.unit.spec.js
+++ b/src/chart-addons/dc-legend-cont.unit.spec.js
@@ -61,8 +61,8 @@ describe("dc legend cont", () => {
       parent.colors().range(["red", "blue", "green"])
       expect(parent.legendablesContinuous()).to.deep.equal([
         { color: "red", value: "5.5" },
-        { color: "blue", value: "8.92" },
-        { color: "green", value: "12.33" }
+        { color: "blue", value: "10.63" },
+        { color: "green", value: "15.75" }
       ])
     })
     it("should round value of legendables for start value over 1000", () => {
@@ -72,8 +72,8 @@ describe("dc legend cont", () => {
       parent.colors().range(["red", "blue", "green"])
       expect(parent.legendablesContinuous()).to.deep.equal([
         { color: "red", value: "1,225" },
-        { color: "blue", value: "1,317" },
-        { color: "green", value: "1,409" }
+        { color: "blue", value: "1,363" },
+        { color: "green", value: "1,501" }
       ])
     })
   })

--- a/src/mixins/raster-layer-poly-mixin.unit.spec.js
+++ b/src/mixins/raster-layer-poly-mixin.unit.spec.js
@@ -92,7 +92,7 @@ describe("rasterLayerPolyMixin", () => {
             name: "polys",
             format: "polys",
             sql:
-              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)",
+              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color0 FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color0 AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)",
             enableHitTesting: false
           }
         ],
@@ -195,7 +195,7 @@ describe("rasterLayerPolyMixin", () => {
             name: "polys",
             format: "polys",
             sql:
-              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)",
+              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color0 FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color0 AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)",
             enableHitTesting: false
           }
         ],
@@ -298,7 +298,7 @@ describe("rasterLayerPolyMixin", () => {
             format: "polys",
             enableHitTesting: false,
             sql:
-              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)"
+              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color0 FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color0 AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)"
           }
         ],
         scales: [
@@ -396,7 +396,7 @@ describe("rasterLayerPolyMixin", () => {
             name: "polys",
             format: "polys",
             sql:
-              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)",
+              "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color0 FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color0 AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)",
             enableHitTesting: false
           },
           {

--- a/src/utils/custom-sql-parser.unit.spec.js
+++ b/src/utils/custom-sql-parser.unit.spec.js
@@ -1,7 +1,7 @@
 import parseFactsFromCustomSQL from "./custom-sql-parser"
 import { expect } from "chai"
 
-describe.only("parseFactsFromCustomSQL", () => {
+describe("parseFactsFromCustomSQL", () => {
   describe("approx_count_distinct(caid) / us_census_block_groups_ca_2017.population", () => {
     const {
       factProjections,


### PR DESCRIPTION
There was an accidental .only() preventing the entire test suite from running. Removes it and fixed some of the tests that needed expected values updated

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
