### PR TITLE
[FE-9710] [FE-8555] Remove loading spinner from chart if there is a c…

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -50186,6 +50186,8 @@ function spinnerMixin(_chart) {
 
   _chart.on("dataError.spinner", function () {
     console.log(_chart.__dcFlag__, ": error");
+
+    tearDownSpinner();
   });
 
   return _chart;

--- a/src/mixins/spinner-mixin.js
+++ b/src/mixins/spinner-mixin.js
@@ -100,6 +100,8 @@ export default function spinnerMixin(_chart) {
 
   _chart.on("dataError.spinner", () => {
     console.log(_chart.__dcFlag__, ": error")
+
+    tearDownSpinner()
   })
 
   return _chart

--- a/src/mixins/spinner-mixin.unit.spec.js
+++ b/src/mixins/spinner-mixin.unit.spec.js
@@ -108,4 +108,10 @@ describe("Spinner Mixin", () => {
       done()
     }, chart.spinnerDelay() + 5)
   })
+
+  it("should clear the spinner if there is an error", () => {
+    chart._invokeDataErrorListener()
+
+    expect(chart.isSpinnerShowing()).to.equal(false)
+  })
 })


### PR DESCRIPTION
…hart render error

A little error handling cleanup. We want to clear any indication that the chart is still loading in the event of an error. This ensures mapd charts handle clearing their loading states themselves rather than relying on the apps using them to externally force a redraw

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [x] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
