### PR TITLE
opacity of zoom and mapbox info icons

### DIFF
--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -1879,6 +1879,9 @@ body {
         font-size: 11px;
         &.mapboxgl-compact {
             bottom: 5px;
+            &::after {
+                opacity: 0.5
+            }
         }
     }
     // Zoom
@@ -2040,11 +2043,10 @@ body {
   display: none !important;
 }
 
-.mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-in {
-  opacity: 0.5;
-}
-
-.mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-out {
+.mapboxgl-ctrl-zoom-in .mapboxgl-ctrl-icon,
+.mapboxgl-ctrl-zoom-in.mapboxgl-ctrl-icon,
+.mapboxgl-ctrl-zoom-out .mapboxgl-ctrl-icon,
+.mapboxgl-ctrl-zoom-out.mapboxgl-ctrl-icon {
   opacity: 0.5;
 }
 


### PR DESCRIPTION
See https://github.com/omnisci/mapd-immerse/pull/6112

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
