### PR TITLE
Add percentage labels, toggle for absolute labels, and 'All Others' slice handling to pie chart

### DIFF
--- a/dist/mapdc.css
+++ b/dist/mapdc.css
@@ -46,6 +46,9 @@ art {
 .dc-chart .pie-slice {
     fill: white;
     font-size: 12px;
+}
+
+.dc-chart .pie-slice:not(.all-others) {
     cursor: pointer;
 }
 
@@ -53,7 +56,7 @@ art {
     fill: black;
 }
 
-.dc-chart .pie-slice :hover {
+.dc-chart .pie-slice:not(.all-others) :hover {
     fill-opacity: .8;
 }
 

--- a/dist/mapdc.css
+++ b/dist/mapdc.css
@@ -604,11 +604,11 @@ body {
     font-weight: bold; }
   .dc-chart .row text {
     fill: #404040 !important; }
-  .dc-chart g.deselected path {
+  .dc-chart g.deselected:not(.pie-slice.all-others) path {
     fill: #c7c7c7; }
-    .dc-chart g.deselected path:hover {
+    .dc-chart g.deselected:not(.pie-slice.all-others) path:hover {
       fill: #e2e2e2; }
-    .dc-chart g.deselected path text {
+    .dc-chart g.deselected:not(.pie-slice.all-others) path text {
       fill-opacity: #a7a7a7; }
   .dc-chart text.deselected-label {
     fill: #868686 !important; }

--- a/dist/mapdc.css
+++ b/dist/mapdc.css
@@ -1555,6 +1555,8 @@ body {
   font-size: 11px; }
   .mapboxgl-ctrl-bottom-right .mapboxgl-ctrl.mapboxgl-ctrl-attrib.mapboxgl-compact {
     bottom: 5px; }
+    .mapboxgl-ctrl-bottom-right .mapboxgl-ctrl.mapboxgl-ctrl-attrib.mapboxgl-compact::after {
+      opacity: 0.5; }
 
 .mapboxgl-ctrl-bottom-right .mapboxgl-ctrl.mapboxgl-ctrl-group {
   margin: 0 10px 10px 0 !important; }
@@ -1662,10 +1664,10 @@ body {
 .mapboxgl-ctrl-compass {
   display: none !important; }
 
-.mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-in {
-  opacity: 0.5; }
-
-.mapboxgl-ctrl-icon.mapboxgl-ctrl-zoom-out {
+.mapboxgl-ctrl-zoom-in .mapboxgl-ctrl-icon,
+.mapboxgl-ctrl-zoom-in.mapboxgl-ctrl-icon,
+.mapboxgl-ctrl-zoom-out .mapboxgl-ctrl-icon,
+.mapboxgl-ctrl-zoom-out.mapboxgl-ctrl-icon {
   opacity: 0.5; }
 
 .mapd-draw-button-circle {

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -76861,6 +76861,10 @@ function pieChart(parent, chartGroup) {
       return ENABLE_ABSOLUTE_LABELS;
     }
     ENABLE_ABSOLUTE_LABELS = showAbsoluteValues;
+
+    if (_hasBeenRendered) {
+      _chart._doRender();
+    }
     return _chart;
   };
 
@@ -76874,6 +76878,10 @@ function pieChart(parent, chartGroup) {
       return ENABLE_PERCENTAGE_LABELS;
     }
     ENABLE_PERCENTAGE_LABELS = showPercentValues;
+
+    if (_hasBeenRendered) {
+      _chart._doRender();
+    }
     return _chart;
   };
 
@@ -76887,6 +76895,10 @@ function pieChart(parent, chartGroup) {
       return ENABLE_ALL_OTHERS_LABELS;
     }
     ENABLE_ALL_OTHERS_LABELS = showAllOthers;
+
+    if (_hasBeenRendered) {
+      _chart._doRender();
+    }
     return _chart;
   };
 

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -76063,9 +76063,6 @@ var _utils = __webpack_require__(4);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var ENABLE_ABSOLUTE_LABELS = true;
-var ENABLE_PERCENTAGE_LABELS = true;
-
 /**
  * The pie chart implementation is usually used to visualize a small categorical distribution.  The pie
  * chart uses keyAccessor to determine the slices, and valueAccessor to calculate the size of each
@@ -76109,7 +76106,9 @@ function pieChart(parent, chartGroup) {
   var _externalLabelRadius = void 0;
   var _drawPaths = false;
   var _chart = (0, _capMixin2.default)((0, _colorMixin2.default)((0, _baseMixin2.default)({})));
-
+  var ENABLE_ABSOLUTE_LABELS = void 0;
+  var ENABLE_PERCENTAGE_LABELS = void 0;
+  var ENABLE_ALL_OTHERS_LABELS = void 0;
   /* OVERRIDE ---------------------------------------------------------------- */
   var _pieStyle = void 0; // "pie" or "donut"
   var _pieSizeThreshold = 480;
@@ -76851,6 +76850,45 @@ function pieChart(parent, chartGroup) {
   }
 
   _chart = (0, _multipleKeyLabelMixin2.default)(_chart);
+
+  /**
+   * Controls Absolute values toggle from immerse
+   * @param showAbsoluteValues
+   * @returns {dc.pieChart|*}
+   */
+  _chart.showAbsoluteValues = function (showAbsoluteValues) {
+    if (!arguments.length) {
+      return ENABLE_ABSOLUTE_LABELS;
+    }
+    ENABLE_ABSOLUTE_LABELS = showAbsoluteValues;
+    return _chart;
+  };
+
+  /**
+   * Controls Percent values toggle from immerse
+   * @param showPercentValues
+   * @returns {dc.pieChart|*}
+   */
+  _chart.showPercentValues = function (showPercentValues) {
+    if (!arguments.length) {
+      return ENABLE_PERCENTAGE_LABELS;
+    }
+    ENABLE_PERCENTAGE_LABELS = showPercentValues;
+    return _chart;
+  };
+
+  /**
+   * Controls All Others value toggle from immerse
+   * @param showAllOthers
+   * @returns {dc.pieChart|*}
+   */
+  _chart.showAllOthers = function (showAllOthers) {
+    if (!arguments.length) {
+      return ENABLE_ALL_OTHERS_LABELS;
+    }
+    ENABLE_ALL_OTHERS_LABELS = showAllOthers;
+    return _chart;
+  };
 
   return _chart.anchor(parent, chartGroup);
 }

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -76199,7 +76199,7 @@ function pieChart(parent, chartGroup) {
 
   (0, _core.override)(_chart, "getColor", function (data, index) {
     if (data.isAllOthers) {
-      return "#aaaaaa";
+      return "#888888";
     }
     return _chart._getColor(data, index);
   });

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -76340,7 +76340,12 @@ function pieChart(parent, chartGroup) {
           if (_d2.default.select(this.parentNode).classed("hide-label")) {
             return "";
           } else {
-            return (0, _formattingHelpers.formatPercentage)(d.value, total);
+            var availableLabelWidth = getAvailableLabelWidth(d);
+            var width = _d2.default.select(this).node().getBoundingClientRect().width;
+
+            var percentage = (0, _formattingHelpers.formatPercentage)(d.value, total);
+
+            return width > availableLabelWidth ? truncateLabel(percentage, width, availableLabelWidth) : percentage;
           }
         });
       }

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -76173,23 +76173,11 @@ function pieChart(parent, chartGroup) {
         return;
       }
 
-      var id = group.getCrossfilterId();
-      var filterSize = new Promise(function (resolve, reject) {
-        var filterSize = (0, _coreAsync.lastFilteredSize)(id);
-        if (filterSize === undefined) {
-          group.getCrossfilter().groupAll().valueAsync().then(function (value) {
-            (0, _coreAsync.setLastFilteredSize)(id, value);
-            resolve(value);
-          }).catch(function (err) {
-            reject(err);
-          });
-        } else {
-          resolve(filterSize);
-        }
-      });
-      filterSize.then(function (filterSize) {
+      group.getCrossfilter().groupAll().valueAsync(false, false, group.dimension().getDimensionIndex()).then(function (filterSize) {
         var val = filterSize - _d2.default.sum(result, _chart.valueAccessor());
-        result.push({ key0: "All Others", val: val, isAllOthers: true });
+        if (val > 0) {
+          result.push({ key0: "All Others", val: val, isAllOthers: true });
+        }
         callback(null, result);
       }).catch(function (err) {
         callback(err);

--- a/mapdc.css
+++ b/mapdc.css
@@ -46,6 +46,9 @@ art {
 .dc-chart .pie-slice {
     fill: white;
     font-size: 12px;
+}
+
+.dc-chart .pie-slice:not(.all-others) {
     cursor: pointer;
 }
 
@@ -53,7 +56,7 @@ art {
     fill: black;
 }
 
-.dc-chart .pie-slice :hover {
+.dc-chart .pie-slice:not(.all-others) :hover {
     fill-opacity: .8;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,8 +78,8 @@
       }
     },
     "@mapd/crossfilter": {
-      "version": "github:omnisci/mapd-crossfilter#06a064d1dad5a9f75cbfff3664b196da9f5ddf6b",
-      "from": "github:omnisci/mapd-crossfilter#06a064d",
+      "version": "github:omnisci/mapd-crossfilter#019e03ad763c76f9ba083a91b5d38156dace9f8f",
+      "from": "github:omnisci/mapd-crossfilter#019e03a",
       "dev": true
     },
     "@mapd/mapd-draw": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@mapd/connector": "omnisci/mapd-connector#d75148077a2a4b23d66d89c63d05c20e5735af2e",
-    "@mapd/crossfilter": "omnisci/mapd-crossfilter#06a064d",
+    "@mapd/crossfilter": "omnisci/mapd-crossfilter#019e03a",
     "atob": "^2.0.3",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -395,7 +395,7 @@ body {
         }
     }
 
-    g.deselected path {
+    g.deselected:not(.pie-slice.all-others) path {
         fill: $gray3;
 
         &:hover {

--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -970,6 +970,10 @@ export default function pieChart(parent, chartGroup) {
       return ENABLE_ABSOLUTE_LABELS
     }
     ENABLE_ABSOLUTE_LABELS = showAbsoluteValues
+
+    if (_hasBeenRendered) {
+      _chart._doRender()
+    }
     return _chart
   }
 
@@ -983,6 +987,10 @@ export default function pieChart(parent, chartGroup) {
       return ENABLE_PERCENTAGE_LABELS
     }
     ENABLE_PERCENTAGE_LABELS = showPercentValues
+
+    if (_hasBeenRendered) {
+      _chart._doRender()
+    }
     return _chart
   }
 
@@ -996,6 +1004,10 @@ export default function pieChart(parent, chartGroup) {
       return ENABLE_ALL_OTHERS_LABELS
     }
     ENABLE_ALL_OTHERS_LABELS = showAllOthers
+
+    if (_hasBeenRendered) {
+      _chart._doRender()
+    }
     return _chart
   }
 

--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -7,9 +7,6 @@ import { formatPercentage, nullLabelHtml } from "../utils/formatting-helpers"
 import { transition } from "../core/core"
 import { utils } from "../utils/utils"
 
-const ENABLE_ABSOLUTE_LABELS = true
-const ENABLE_PERCENTAGE_LABELS = true
-
 /**
  * The pie chart implementation is usually used to visualize a small categorical distribution.  The pie
  * chart uses keyAccessor to determine the slices, and valueAccessor to calculate the size of each
@@ -52,7 +49,9 @@ export default function pieChart(parent, chartGroup) {
   let _externalLabelRadius
   let _drawPaths = false
   let _chart = capMixin(colorMixin(baseMixin({})))
-
+  let ENABLE_ABSOLUTE_LABELS
+  let ENABLE_PERCENTAGE_LABELS
+  let ENABLE_ALL_OTHERS_LABELS
   /* OVERRIDE ---------------------------------------------------------------- */
   let _pieStyle // "pie" or "donut"
   const _pieSizeThreshold = 480
@@ -960,6 +959,45 @@ export default function pieChart(parent, chartGroup) {
   }
 
   _chart = multipleKeysLabelMixin(_chart)
+
+  /**
+   * Controls Absolute values toggle from immerse
+   * @param showAbsoluteValues
+   * @returns {dc.pieChart|*}
+   */
+  _chart.showAbsoluteValues = function(showAbsoluteValues) {
+    if (!arguments.length) {
+      return ENABLE_ABSOLUTE_LABELS
+    }
+    ENABLE_ABSOLUTE_LABELS = showAbsoluteValues
+    return _chart
+  }
+
+  /**
+   * Controls Percent values toggle from immerse
+   * @param showPercentValues
+   * @returns {dc.pieChart|*}
+   */
+  _chart.showPercentValues = function(showPercentValues) {
+    if (!arguments.length) {
+      return ENABLE_PERCENTAGE_LABELS
+    }
+    ENABLE_PERCENTAGE_LABELS = showPercentValues
+    return _chart
+  }
+
+  /**
+   * Controls All Others value toggle from immerse
+   * @param showAllOthers
+   * @returns {dc.pieChart|*}
+   */
+  _chart.showAllOthers = function(showAllOthers) {
+    if (!arguments.length) {
+      return ENABLE_ALL_OTHERS_LABELS
+    }
+    ENABLE_ALL_OTHERS_LABELS = showAllOthers
+    return _chart
+  }
 
   return _chart.anchor(parent, chartGroup)
 }

--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -325,7 +325,17 @@ export default function pieChart(parent, chartGroup) {
             if (d3.select(this.parentNode).classed("hide-label")) {
               return ""
             } else {
-              return formatPercentage(d.value, total)
+              const availableLabelWidth = getAvailableLabelWidth(d)
+              const width = d3
+                .select(this)
+                .node()
+                .getBoundingClientRect().width
+
+              const percentage = formatPercentage(d.value, total)
+
+              return width > availableLabelWidth
+                ? truncateLabel(percentage, width, availableLabelWidth)
+                : percentage
             }
           })
       }

--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -141,7 +141,7 @@ export default function pieChart(parent, chartGroup) {
 
   override(_chart, "getColor", (data, index) => {
     if (data.isAllOthers) {
-      return "#aaaaaa"
+      return "#888888"
     }
     return _chart._getColor(data, index)
   })

--- a/src/utils/formatting-helpers.js
+++ b/src/utils/formatting-helpers.js
@@ -66,6 +66,18 @@ export function formatNumber(d) {
   }
 }
 
+const percentify = d3.format(".0%")
+const percentifyLow = d3.format(".1%")
+
+export function formatPercentage(d, total) {
+  const percentage = d / total
+  if (percentage < 0.01) {
+    return percentifyLow(percentage)
+  } else {
+    return percentify(percentage)
+  }
+}
+
 export function formatArrayValue(data) {
   if (typeof data[0] === "object" && !(data[0] instanceof Date)) {
     return data[0].isExtract


### PR DESCRIPTION
* Adds percentage labels accounting for the sum total of all slices' values
* Adds toggling methods for both percentage labels and the original absolute value labels
* Adds an 'All Others' slice that cannot be filtered and shows the value for all remaining values on the dimension that are not represented by a specific slice.