### PR TITLE
Guard chart data access in pie chart drawChart

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -76218,9 +76218,12 @@ function pieChart(parent, chartGroup) {
     var arc = buildArcs();
 
     var pie = pieLayout();
+
+    var chartData = _chart.data();
+
     var pieData = void 0;
     // if we have data...
-    if (_d2.default.sum(_chart.data(), _chart.valueAccessor())) {
+    if (chartData && _d2.default.sum(chartData, _chart.valueAccessor())) {
       pieData = pie(_utils.utils.maybeFormatInfinity(_chart.data()));
       _g.classed(_emptyCssClass, false);
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,8 +78,8 @@
       }
     },
     "@mapd/crossfilter": {
-      "version": "github:omnisci/mapd-crossfilter#019e03ad763c76f9ba083a91b5d38156dace9f8f",
-      "from": "github:omnisci/mapd-crossfilter#019e03a",
+      "version": "github:omnisci/mapd-crossfilter#d66b00cd87c419a3e0222f8ea498fac78acca492",
+      "from": "github:omnisci/mapd-crossfilter#d66b00c",
       "dev": true
     },
     "@mapd/mapd-draw": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@mapd/connector": "omnisci/mapd-connector#d75148077a2a4b23d66d89c63d05c20e5735af2e",
-    "@mapd/crossfilter": "omnisci/mapd-crossfilter#019e03a",
+    "@mapd/crossfilter": "omnisci/mapd-crossfilter#d66b00c",
     "atob": "^2.0.3",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",

--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -169,9 +169,12 @@ export default function pieChart(parent, chartGroup) {
     const arc = buildArcs()
 
     const pie = pieLayout()
+
+    const chartData = _chart.data()
+
     let pieData
     // if we have data...
-    if (d3.sum(_chart.data(), _chart.valueAccessor())) {
+    if (chartData && d3.sum(chartData, _chart.valueAccessor())) {
       pieData = pie(utils.maybeFormatInfinity(_chart.data()))
       _g.classed(_emptyCssClass, false)
     } else {


### PR DESCRIPTION
Pie chart was accessing chart.data() in drawChart - in some scenarios, that can resolve to undefined just after an update, after the new percent labels / all others options were added.