### PR TITLE
Cap the number of ticks for extract dimension too, in coordinate-grid-mixin

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -11491,12 +11491,15 @@ function coordinateGridMixin(_chart) {
   _chart.getNumTicksForXAxis = function () {
     var xDomain = _chart.x().domain();
     var timeBinParam = _chart.group().binParams()[DEFAULT_TIME_DIMENSION_INDEX];
-
-    var numTicks = timeBinParam && timeBinParam.extract ? xDomain[xDomain.length - 1] - xDomain[0] : _chart.xAxis().scale().ticks().length;
-
     var effectiveWidth = _chart.effectiveWidth();
 
-    return effectiveWidth / numTicks < MAX_TICK_WIDTH ? Math.ceil(effectiveWidth / MAX_TICK_WIDTH) : DEFAULT_NUM_TICKS;
+    if (timeBinParam && timeBinParam.extract) {
+      var numTicks = xDomain[xDomain.length - 1] - xDomain[0];
+      return effectiveWidth / numTicks < MAX_TICK_WIDTH ? Math.ceil(effectiveWidth / MAX_TICK_WIDTH) : numTicks;
+    } else {
+      var _numTicks = _chart.xAxis().scale().ticks().length;
+      return effectiveWidth / _numTicks < MAX_TICK_WIDTH ? Math.ceil(effectiveWidth / MAX_TICK_WIDTH) : DEFAULT_NUM_TICKS;
+    }
   };
 
   _chart.rangeFocused = function (_) {

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -11491,13 +11491,12 @@ function coordinateGridMixin(_chart) {
   _chart.getNumTicksForXAxis = function () {
     var xDomain = _chart.x().domain();
     var timeBinParam = _chart.group().binParams()[DEFAULT_TIME_DIMENSION_INDEX];
-    if (timeBinParam && timeBinParam.extract) {
-      return xDomain[xDomain.length - 1] - xDomain[0];
-    } else {
-      var effectiveWidth = _chart.effectiveWidth();
-      var numTicks = _chart.xAxis().scale().ticks().length;
-      return effectiveWidth / numTicks < MAX_TICK_WIDTH ? Math.ceil(effectiveWidth / MAX_TICK_WIDTH) : DEFAULT_NUM_TICKS;
-    }
+
+    var numTicks = timeBinParam && timeBinParam.extract ? xDomain[xDomain.length - 1] - xDomain[0] : _chart.xAxis().scale().ticks().length;
+
+    var effectiveWidth = _chart.effectiveWidth();
+
+    return effectiveWidth / numTicks < MAX_TICK_WIDTH ? Math.ceil(effectiveWidth / MAX_TICK_WIDTH) : DEFAULT_NUM_TICKS;
   };
 
   _chart.rangeFocused = function (_) {

--- a/src/mixins/coordinate-grid-mixin.js
+++ b/src/mixins/coordinate-grid-mixin.js
@@ -1579,14 +1579,15 @@ export default function coordinateGridMixin (_chart) {
     const timeBinParam = _chart.group().binParams()[
       DEFAULT_TIME_DIMENSION_INDEX
     ]
-    
-    const numTicks = timeBinParam && timeBinParam.extract
-      ? xDomain[xDomain.length - 1] - xDomain[0]
-      : _chart.xAxis().scale().ticks().length
-
     const effectiveWidth = _chart.effectiveWidth()
 
-    return effectiveWidth / numTicks < MAX_TICK_WIDTH ? Math.ceil(effectiveWidth / MAX_TICK_WIDTH) : DEFAULT_NUM_TICKS
+    if (timeBinParam && timeBinParam.extract) {
+      const numTicks = xDomain[xDomain.length - 1] - xDomain[0]
+      return effectiveWidth / numTicks < MAX_TICK_WIDTH ? Math.ceil(effectiveWidth / MAX_TICK_WIDTH) : numTicks
+    } else {
+      const numTicks = _chart.xAxis().scale().ticks().length
+      return effectiveWidth / numTicks < MAX_TICK_WIDTH ? Math.ceil(effectiveWidth / MAX_TICK_WIDTH) : DEFAULT_NUM_TICKS
+    }
   }
 
   _chart.rangeFocused = function (_) {

--- a/src/mixins/coordinate-grid-mixin.js
+++ b/src/mixins/coordinate-grid-mixin.js
@@ -1579,13 +1579,14 @@ export default function coordinateGridMixin (_chart) {
     const timeBinParam = _chart.group().binParams()[
       DEFAULT_TIME_DIMENSION_INDEX
     ]
-    if (timeBinParam && timeBinParam.extract) {
-      return xDomain[xDomain.length - 1] - xDomain[0]
-    } else {
-      const effectiveWidth = _chart.effectiveWidth()
-      const numTicks = _chart.xAxis().scale().ticks().length
-      return effectiveWidth / numTicks < MAX_TICK_WIDTH ? Math.ceil(effectiveWidth / MAX_TICK_WIDTH) : DEFAULT_NUM_TICKS
-    }
+    
+    const numTicks = timeBinParam && timeBinParam.extract
+      ? xDomain[xDomain.length - 1] - xDomain[0]
+      : _chart.xAxis().scale().ticks().length
+
+    const effectiveWidth = _chart.effectiveWidth()
+
+    return effectiveWidth / numTicks < MAX_TICK_WIDTH ? Math.ceil(effectiveWidth / MAX_TICK_WIDTH) : DEFAULT_NUM_TICKS
   }
 
   _chart.rangeFocused = function (_) {

--- a/src/mixins/coordinate-grid-mixin.unit.spec.js
+++ b/src/mixins/coordinate-grid-mixin.unit.spec.js
@@ -30,6 +30,7 @@ describe("coordinateGridMixin", () => {
       })
     })
     it("should handle extract case", () => {
+      chart.effectiveWidth = () => 150
       expect(chart.getNumTicksForXAxis()).to.equal(3)
     })
     it("should handle non-extract case", () => {


### PR DESCRIPTION
The getNumTicksForXAxis method in coordinate-grid-mixin was capping the number of ticks based on the chart width for normal dimensions, but not when the chart group had an extract time dimension. This change fixes that, correcting an issue with the bubble-mixin on top of it primarily.