### PR TITLE
Pie chart: Use size measure (first index from crossfilter reduce array) for the valueAsync call for the All Others value

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -76176,7 +76176,15 @@ function pieChart(parent, chartGroup) {
         return;
       }
 
-      group.getCrossfilter().groupAll().valueAsync(false, false, group.dimension().getDimensionIndex()).then(function (filterSize) {
+      // Get the total value (across the whole table, no groups) for the current
+      // size measure and incoming crossfilters
+      group.getCrossfilter().groupAll()
+
+      // Include the size measure
+      .reduce([group.reduce()[0]])
+
+      // Add the chart's own dimension index which excludes its filters
+      .valueAsync(false, false, group.dimension().getDimensionIndex()).then(function (filterSize) {
         var val = filterSize - _d2.default.sum(result, _chart.valueAccessor());
         if (val > 0) {
           result.push({ key0: "All Others", val: val, isAllOthers: true });

--- a/src/charts/pie-chart.js
+++ b/src/charts/pie-chart.js
@@ -116,10 +116,18 @@ export default function pieChart(parent, chartGroup) {
         return
       }
 
+      // Get the total value (across the whole table, no groups) for the current
+      // size measure and incoming crossfilters
       group
         .getCrossfilter()
         .groupAll()
+
+        // Include the size measure
+        .reduce([group.reduce()[0]])
+
+        // Add the chart's own dimension index which excludes its filters
         .valueAsync(false, false, group.dimension().getDimensionIndex())
+
         .then(filterSize => {
           const val = filterSize - d3.sum(result, _chart.valueAccessor())
           if (val > 0) {


### PR DESCRIPTION
Use size measure in valueAsync call for total calculation when All Others value is enabled for pie chart, so that it calculates the proper total when the measure aggregate is not # Records (such as Sum).