### PR TITLE
[FE-10291] Add range slider for bubble charts

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -33096,6 +33096,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  */
 function bubbleMixin(_chart) {
   var _maxBubbleRelativeSize = 0.3;
+  var _minBubbleRelativeSize = 0.004;
 
   /* OVERRIDE ---------------------------------------------------------------- */
   var _minRadiusWithLabel = 2;
@@ -33314,6 +33315,14 @@ function bubbleMixin(_chart) {
       return _maxBubbleRelativeSize;
     }
     _maxBubbleRelativeSize = relativeSize;
+    return _chart;
+  };
+
+  _chart.minBubbleRelativeSize = function (relativeSize) {
+    if (!arguments.length) {
+      return _minBubbleRelativeSize;
+    }
+    _minBubbleRelativeSize = relativeSize;
     return _chart;
   };
 
@@ -69781,6 +69790,8 @@ function bubbleChart(parent, chartGroup) {
 
   var _elasticRadius = false;
   var _sortBubbleSize = false;
+  var _hasSizeMeasure = false;
+  var SMALLEST_SIZED_BUBBLE_RADIUS = 2;
 
   _chart.transitionDuration(750);
 
@@ -70024,6 +70035,14 @@ function bubbleChart(parent, chartGroup) {
     return _chart;
   };
 
+  _chart.hasSizeMeasure = function (hasSizeMeasure) {
+    if (!arguments.length) {
+      return _hasSizeMeasure;
+    }
+    _hasSizeMeasure = hasSizeMeasure;
+    return _chart;
+  };
+
   /**
    * Turn on or off the bubble sorting feature, or return the value of the flag. If enabled,
    * bubbles will be sorted by their radius, with smaller bubbles in front.
@@ -70047,7 +70066,22 @@ function bubbleChart(parent, chartGroup) {
       _chart.r().domain([_chart.rMin(), _chart.rMax()]);
     }
 
-    _chart.r().range([_chart.MIN_RADIUS, _chart.xAxisLength() * _chart.maxBubbleRelativeSize()]);
+    // If the chart has a size measure, we're going to render bubbles
+    // differently than if the chart doesn't have a size measure
+    if (_hasSizeMeasure) {
+      // If it has a size measure, we're going to scale the bubbles. This scale
+      // is a function of a multiplier and the chart width. We allow the user to
+      // select the multiplier for the lower and upper bounds of bubble radii.
+      // However, we want to enforce an absolute minimum radius of 2px on
+      // rendered bubbles.
+      var minimumBubbleSizeInPixels = Math.max(SMALLEST_SIZED_BUBBLE_RADIUS, _chart.xAxisLength() * _chart.minBubbleRelativeSize());
+      _chart.r().range([minimumBubbleSizeInPixels, _chart.xAxisLength() * _chart.maxBubbleRelativeSize()]);
+    } else {
+      // If we have a size measure, the bubble size will be a fixed radius
+      // determined by the user and stored in _chart.MIN_RADIUS. This fixed with
+      // is not responsive and will not vary with screen size.
+      _chart.r().range([_chart.MIN_RADIUS, _chart.MIN_RADIUS]);
+    }
 
     var data = _chart.data();
     if (_sortBubbleSize) {

--- a/src/charts/bubble-chart.js
+++ b/src/charts/bubble-chart.js
@@ -40,6 +40,8 @@ export default function bubbleChart(parent, chartGroup) {
 
   let _elasticRadius = false
   let _sortBubbleSize = false
+  let _hasSizeMeasure = false
+  const SMALLEST_SIZED_BUBBLE_RADIUS = 2
 
   _chart.transitionDuration(750)
 
@@ -400,6 +402,14 @@ export default function bubbleChart(parent, chartGroup) {
     return _chart
   }
 
+  _chart.hasSizeMeasure = function(hasSizeMeasure) {
+    if (!arguments.length) {
+      return _hasSizeMeasure
+    }
+    _hasSizeMeasure = hasSizeMeasure
+    return _chart
+  }
+
   /**
    * Turn on or off the bubble sorting feature, or return the value of the flag. If enabled,
    * bubbles will be sorted by their radius, with smaller bubbles in front.
@@ -423,12 +433,30 @@ export default function bubbleChart(parent, chartGroup) {
       _chart.r().domain([_chart.rMin(), _chart.rMax()])
     }
 
-    _chart
-      .r()
-      .range([
-        _chart.MIN_RADIUS,
-        _chart.xAxisLength() * _chart.maxBubbleRelativeSize()
-      ])
+    // If the chart has a size measure, we're going to render bubbles
+    // differently than if the chart doesn't have a size measure
+    if (_hasSizeMeasure) {
+      // If it has a size measure, we're going to scale the bubbles. This scale
+      // is a function of a multiplier and the chart width. We allow the user to
+      // select the multiplier for the lower and upper bounds of bubble radii.
+      // However, we want to enforce an absolute minimum radius of 2px on
+      // rendered bubbles.
+      const minimumBubbleSizeInPixels = Math.max(
+        SMALLEST_SIZED_BUBBLE_RADIUS,
+        _chart.xAxisLength() * _chart.minBubbleRelativeSize()
+      )
+      _chart
+        .r()
+        .range([
+          minimumBubbleSizeInPixels,
+          _chart.xAxisLength() * _chart.maxBubbleRelativeSize()
+        ])
+    } else {
+      // If we have a size measure, the bubble size will be a fixed radius
+      // determined by the user and stored in _chart.MIN_RADIUS. This fixed with
+      // is not responsive and will not vary with screen size.
+      _chart.r().range([_chart.MIN_RADIUS, _chart.MIN_RADIUS])
+    }
 
     const data = _chart.data()
     if (_sortBubbleSize) {

--- a/src/mixins/bubble-mixin.js
+++ b/src/mixins/bubble-mixin.js
@@ -12,6 +12,7 @@ import { transition } from "../core/core"
  */
 export default function bubbleMixin(_chart) {
   let _maxBubbleRelativeSize = 0.3
+  let _minBubbleRelativeSize = 0.004
 
   /* OVERRIDE ---------------------------------------------------------------- */
   let _minRadiusWithLabel = 2
@@ -236,6 +237,14 @@ export default function bubbleMixin(_chart) {
       return _maxBubbleRelativeSize
     }
     _maxBubbleRelativeSize = relativeSize
+    return _chart
+  }
+
+  _chart.minBubbleRelativeSize = function(relativeSize) {
+    if (!arguments.length) {
+      return _minBubbleRelativeSize
+    }
+    _minBubbleRelativeSize = relativeSize
     return _chart
   }
 


### PR DESCRIPTION
[Required reading](https://github.com/omnisci/mapd-immerse/pull/6151)

See my [Immerse PR here](https://github.com/omnisci/mapd-immerse/pull/6169)

Herein lie changes that allow us to have a range slider for sized bubble charts in Immerse.

- Passes a boolean regarding whether or not the chart currently has a size measure
- Adds a default absolute minimum pixel radius for sized bubbles (bubble charts with a size measure)
- Adds a default minimum size ratio for sized bubbles
- Modifies `plotData` to have two different paths for assigning bubble size ranges, depending on whether there's a size measure or not. 
   - Unsized bubbles have a fixed pixel size 
   - Sized bubbles are scaled. This scale is a function of an arbitrary multiplier and the chart's width. This means that sized bubbles are responsive to changes in chart width. We allow the user to modify the multipliers for the lower and upper bounds. However, we have an *absolute* minimum radius of 2 pixels, so that bubbles don't disappear


