### PR TITLE
[FE-10310] circle exceptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,8 +78,8 @@
       }
     },
     "@mapd/crossfilter": {
-      "version": "github:omnisci/mapd-crossfilter#088eb039c9846326d281b27c90190b0032226601",
-      "from": "github:omnisci/mapd-crossfilter#088eb039c9846326d281b27c90190b0032226601",
+      "version": "github:omnisci/mapd-crossfilter#6f291acdef3c0c79f3b12cea35bd3313423aa303",
+      "from": "github:omnisci/mapd-crossfilter#6f291ac",
       "dev": true
     },
     "@mapd/mapd-draw": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,8 +78,8 @@
       }
     },
     "@mapd/crossfilter": {
-      "version": "github:omnisci/mapd-crossfilter#d66b00cd87c419a3e0222f8ea498fac78acca492",
-      "from": "github:omnisci/mapd-crossfilter#d66b00c",
+      "version": "github:omnisci/mapd-crossfilter#088eb039c9846326d281b27c90190b0032226601",
+      "from": "github:omnisci/mapd-crossfilter#088eb039c9846326d281b27c90190b0032226601",
       "dev": true
     },
     "@mapd/mapd-draw": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@mapd/connector": "omnisci/mapd-connector#d75148077a2a4b23d66d89c63d05c20e5735af2e",
-    "@mapd/crossfilter": "omnisci/mapd-crossfilter#088eb039c9846326d281b27c90190b0032226601",
+    "@mapd/crossfilter": "omnisci/mapd-crossfilter#6f291ac",
     "atob": "^2.0.3",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   },
   "devDependencies": {
     "@mapd/connector": "omnisci/mapd-connector#d75148077a2a4b23d66d89c63d05c20e5735af2e",
-    "@mapd/crossfilter": "omnisci/mapd-crossfilter#d66b00c",
+    "@mapd/crossfilter": "omnisci/mapd-crossfilter#088eb039c9846326d281b27c90190b0032226601",
     "atob": "^2.0.3",
     "babel-cli": "^6.10.1",
     "babel-core": "^6.10.4",


### PR DESCRIPTION
### :speech_balloon: Description

We can't call ST_GeomFromText w/o passing in a projection.

omnisci db DOES allow different projections in geostring columns, but also currently ASSUMES they're all 4326 no matter what. There's also no current way to get the projection on a geocolumn.

So we just assume that it's always 4326 and pass that into ST_GeomFromText(), even though the coordinates had already been translated into 4326 anyway.

Stops an exception from being thrown for using a differing SRID, even though they're all 4326. AFAICT, that's an old error that's only surface recently since we started reporting the exception instead of letting it die on the console.

### :page_facing_up: Jira Issue

Closes [FE-10310](https://jira.omnisci.com/browse/FE-10310)

### :mag: Verification Steps

1.
2.
3.

### :camera_flash: Screenshot

