### PR TITLE
Make enableHitTesting always true for poly

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -54679,7 +54679,7 @@ function rasterLayerPolyMixin(_layer) {
           lastFilteredSize: lastFilteredSize
         })
       }),
-      enableHitTesting: state.enableHitTesting
+      enableHitTesting: true // poly enableHitTesting will be always true to support 1. Hittesting 2. poly selection filter
     }];
 
     if (autocolors) {

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -394,7 +394,7 @@ export default function rasterLayerPolyMixin(_layer) {
             lastFilteredSize
           })
         }),
-        enableHitTesting: state.enableHitTesting
+        enableHitTesting: true // poly enableHitTesting will be always true to support 1. Hittesting 2. poly selection filter
       }
     ]
 

--- a/src/mixins/raster-layer-poly-mixin.unit.spec.js
+++ b/src/mixins/raster-layer-poly-mixin.unit.spec.js
@@ -74,7 +74,7 @@ describe("rasterLayerPolyMixin", () => {
           geocol: "mapd_geo",
           geoTable: "zipcodes"
         },
-        enableHitTesting: false
+        enableHitTesting: true
       })
       layer.crossfilter({
         getId: () => 1
@@ -94,7 +94,7 @@ describe("rasterLayerPolyMixin", () => {
             format: "polys",
             sql:
               "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color0 FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color0 AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)",
-            enableHitTesting: false
+            enableHitTesting: true
           }
         ],
         scales: [
@@ -178,7 +178,7 @@ describe("rasterLayerPolyMixin", () => {
           geocol: "mapd_geo",
           geoTable: "zipcodes"
         },
-        enableHitTesting: false
+        enableHitTesting: true
       })
       layer.crossfilter({
         getId: () => 1
@@ -198,7 +198,7 @@ describe("rasterLayerPolyMixin", () => {
             format: "polys",
             sql:
               "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color0 FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color0 AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)",
-            enableHitTesting: false
+            enableHitTesting: true
           }
         ],
         scales: [
@@ -281,7 +281,7 @@ describe("rasterLayerPolyMixin", () => {
           geocol: "mapd_geo",
           geoTable: "zipcodes"
         },
-        enableHitTesting: false
+        enableHitTesting: true
       })
       layer.crossfilter({
         getId: () => 1
@@ -299,7 +299,7 @@ describe("rasterLayerPolyMixin", () => {
           {
             name: "polys",
             format: "polys",
-            enableHitTesting: false,
+            enableHitTesting: true,
             sql:
               "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color0 FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color0 AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)"
           }
@@ -382,7 +382,7 @@ describe("rasterLayerPolyMixin", () => {
           geocol: "mapd_geo",
           geoTable: "zipcodes"
         },
-        enableHitTesting: false
+        enableHitTesting: true
       })
       layer.crossfilter({
         getId: () => 1
@@ -401,7 +401,7 @@ describe("rasterLayerPolyMixin", () => {
             format: "polys",
             sql:
               "WITH colors AS (SELECT contributions_donotmodify.contributor_zipcode AS key0, AVG(contributions_donotmodify.amount) AS color0 FROM contributions_donotmodify WHERE (amount=0) GROUP BY key0) SELECT zipcodes.mapd_geo AS mapd_geo, colors.key0 AS key0, colors.color0 AS color FROM zipcodes, colors WHERE (zipcodes.ZCTA5CE10 = colors.key0)",
-            enableHitTesting: false
+            enableHitTesting: true
           },
           {
             name: "polys_stats",


### PR DESCRIPTION
## Description:
From previous work that made enableHitTesting to be dynamic is not suitable for poly right now because poly needs selection filter that requires enableHitTesting to be true. Thus, we set it to `true` always until we add a poly selection filter handler (ex: enable/disable toggle). This toggle will prevent sending constant hit testing requests which caused some issues like IQT experiences.
# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #https://jira.omnisci.com/browse/FE-10315

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
