### PR TITLE
[FE-10328] include capMixin for heatmap

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -9703,53 +9703,6 @@ function colorMixin(_chart) {
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-var events = exports.events = {
-  current: null
-
-  /**
-   * This function triggers a throttled event function with a specified delay (in milli-seconds).  Events
-   * that are triggered repetitively due to user interaction such brush dragging might flood the library
-   * and invoke more renders than can be executed in time. Using this function to wrap your event
-   * function allows the library to smooth out the rendering by throttling events and only responding to
-   * the most recent event.
-   * @name events.trigger
-   * @memberof dc
-   * @example
-   * chart.on('renderlet', function(chart) {
-   *     // smooth the rendering through event throttling
-   *     dc.events.trigger(function(){
-   *         // focus some other chart to the range selected by user on this chart
-   *         someOtherChart.focus(chart.filter());
-   *     });
-   * })
-   * @param {Function} closure
-   * @param {Number} [delay]
-   */
-};events.trigger = function (closure, delay) {
-  if (!delay) {
-    closure();
-    return;
-  }
-
-  events.current = closure;
-
-  setTimeout(function () {
-    if (closure === events.current) {
-      closure();
-    }
-  }, delay);
-};
-
-/***/ }),
-/* 14 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-Object.defineProperty(exports, "__esModule", {
-  value: true
-});
 exports.default = capMixin;
 
 var _d = __webpack_require__(1);
@@ -9979,6 +9932,53 @@ function capMixin(_chart) {
 }
 
 /***/ }),
+/* 14 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var events = exports.events = {
+  current: null
+
+  /**
+   * This function triggers a throttled event function with a specified delay (in milli-seconds).  Events
+   * that are triggered repetitively due to user interaction such brush dragging might flood the library
+   * and invoke more renders than can be executed in time. Using this function to wrap your event
+   * function allows the library to smooth out the rendering by throttling events and only responding to
+   * the most recent event.
+   * @name events.trigger
+   * @memberof dc
+   * @example
+   * chart.on('renderlet', function(chart) {
+   *     // smooth the rendering through event throttling
+   *     dc.events.trigger(function(){
+   *         // focus some other chart to the range selected by user on this chart
+   *         someOtherChart.focus(chart.filter());
+   *     });
+   * })
+   * @param {Function} closure
+   * @param {Number} [delay]
+   */
+};events.trigger = function (closure, delay) {
+  if (!delay) {
+    closure();
+    return;
+  }
+
+  events.current = closure;
+
+  setTimeout(function () {
+    if (closure === events.current) {
+      closure();
+    }
+  }, delay);
+};
+
+/***/ }),
 /* 15 */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -10008,7 +10008,7 @@ var _d = __webpack_require__(1);
 
 var _d2 = _interopRequireDefault(_d);
 
-var _events = __webpack_require__(13);
+var _events = __webpack_require__(14);
 
 var _filters = __webpack_require__(20);
 
@@ -54303,7 +54303,7 @@ var _d = __webpack_require__(1);
 
 var _d2 = _interopRequireDefault(_d);
 
-var _events = __webpack_require__(13);
+var _events = __webpack_require__(14);
 
 var _utils = __webpack_require__(4);
 
@@ -57319,7 +57319,7 @@ Object.keys(_coreAsync).forEach(function (key) {
   });
 });
 
-var _events = __webpack_require__(13);
+var _events = __webpack_require__(14);
 
 Object.keys(_events).forEach(function (key) {
   if (key === "default" || key === "__esModule") return;
@@ -57556,7 +57556,7 @@ Object.defineProperty(exports, "bubbleMixin", {
   }
 });
 
-var _capMixin = __webpack_require__(14);
+var _capMixin = __webpack_require__(13);
 
 Object.defineProperty(exports, "capMixin", {
   enumerable: true,
@@ -59251,7 +59251,7 @@ var _bubbleMixin = __webpack_require__(35);
 
 var _bubbleMixin2 = _interopRequireDefault(_bubbleMixin);
 
-var _capMixin = __webpack_require__(14);
+var _capMixin = __webpack_require__(13);
 
 var _capMixin2 = _interopRequireDefault(_capMixin);
 
@@ -59788,7 +59788,7 @@ exports.default = filterMixin;
 
 var _formattingHelpers = __webpack_require__(10);
 
-var _events = __webpack_require__(13);
+var _events = __webpack_require__(14);
 
 var noop = function noop() {}; // eslint-disable-line no-empty-function
 
@@ -69536,7 +69536,7 @@ var _d = __webpack_require__(1);
 
 var _d2 = _interopRequireDefault(_d);
 
-var _events = __webpack_require__(13);
+var _events = __webpack_require__(14);
 
 var _filters = __webpack_require__(20);
 
@@ -69732,7 +69732,7 @@ var _bubbleMixin = __webpack_require__(35);
 
 var _bubbleMixin2 = _interopRequireDefault(_bubbleMixin);
 
-var _capMixin = __webpack_require__(14);
+var _capMixin = __webpack_require__(13);
 
 var _capMixin2 = _interopRequireDefault(_capMixin);
 
@@ -70175,7 +70175,7 @@ var _baseMixin = __webpack_require__(6);
 
 var _baseMixin2 = _interopRequireDefault(_baseMixin);
 
-var _capMixin = __webpack_require__(14);
+var _capMixin = __webpack_require__(13);
 
 var _capMixin2 = _interopRequireDefault(_capMixin);
 
@@ -75316,13 +75316,17 @@ var _marginMixin = __webpack_require__(17);
 
 var _marginMixin2 = _interopRequireDefault(_marginMixin);
 
-var _events = __webpack_require__(13);
+var _events = __webpack_require__(14);
 
 var _core = __webpack_require__(3);
 
 var _utils = __webpack_require__(4);
 
 var _filters = __webpack_require__(20);
+
+var _capMixin = __webpack_require__(13);
+
+var _capMixin2 = _interopRequireDefault(_capMixin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -75473,9 +75477,10 @@ function heatMap(parent, chartGroup) {
   };var _xBorderRadius = DEFAULT_BORDER_RADIUS;
   var _yBorderRadius = DEFAULT_BORDER_RADIUS;
 
-  var _chart = (0, _colorMixin2.default)((0, _marginMixin2.default)((0, _baseMixin2.default)({})));
+  var _chart = (0, _colorMixin2.default)((0, _capMixin2.default)((0, _marginMixin2.default)((0, _baseMixin2.default)({}))));
   _chart._mandatoryAttributes(["group"]);
   _chart.title(_chart.colorAccessor());
+  _chart.boxCap = _chart.cap;
 
   var _colsLabel = function _colsLabel(d) {
     return d;
@@ -76041,7 +76046,7 @@ var _baseMixin = __webpack_require__(6);
 
 var _baseMixin2 = _interopRequireDefault(_baseMixin);
 
-var _capMixin = __webpack_require__(14);
+var _capMixin = __webpack_require__(13);
 
 var _capMixin2 = _interopRequireDefault(_capMixin);
 
@@ -82492,7 +82497,7 @@ var _baseMixin = __webpack_require__(6);
 
 var _baseMixin2 = _interopRequireDefault(_baseMixin);
 
-var _capMixin = __webpack_require__(14);
+var _capMixin = __webpack_require__(13);
 
 var _capMixin2 = _interopRequireDefault(_capMixin);
 
@@ -83165,7 +83170,7 @@ var _d = __webpack_require__(1);
 
 var _d2 = _interopRequireDefault(_d);
 
-var _events = __webpack_require__(13);
+var _events = __webpack_require__(14);
 
 var _filters = __webpack_require__(20);
 
@@ -87420,7 +87425,7 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 exports.default = rasterLayer;
 
-var _capMixin = __webpack_require__(14);
+var _capMixin = __webpack_require__(13);
 
 var _capMixin2 = _interopRequireDefault(_capMixin);
 

--- a/src/charts/heatmap.js
+++ b/src/charts/heatmap.js
@@ -7,6 +7,7 @@ import { events } from "../core/events"
 import { override, transition } from "../core/core"
 import { utils } from "../utils/utils"
 import { filters } from "../core/filters"
+import capMixin from "../mixins/cap-mixin"
 
 /** ***************************************************************************
  * OVERRIDE: dc.heatMap                                                       *
@@ -192,9 +193,10 @@ export default function heatMap(parent, chartGroup) {
   var _xBorderRadius = DEFAULT_BORDER_RADIUS
   var _yBorderRadius = DEFAULT_BORDER_RADIUS
 
-  const _chart = colorMixin(marginMixin(baseMixin({})))
+  const _chart = colorMixin(capMixin(marginMixin(baseMixin({}))))
   _chart._mandatoryAttributes(["group"])
   _chart.title(_chart.colorAccessor())
+  _chart.boxCap = _chart.cap
 
   let _colsLabel = function(d) {
     return d


### PR DESCRIPTION
## Description: 
This issue has been present in the Heat chart for years. The infinite loop only happens when the chart is filtered (by clicking on a box or an axis) before the chart is saved. The click filter logic is in nested promises in mixins but that seems like assuming the cap-mixin.js logic is included like row and pie chart. Thus, without setting the cap value for the heat chart is causing the unresolved promise when the chart is initialized. Setting the cap value and including the cap-mixin in the heat chart doesn't seem to cause any issue. The default cap value is hardcoded because we don't have a slider to control it. Setting a reasonable cap value is essential to show enough boxes.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #https://jira.omnisci.com/browse/FE-10328

## Relates with: 
https://github.com/omnisci/mapd-immerse/pull/6196

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
