### PR TITLE
strokeColor: "fillColor"

### DIFF
--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -486,6 +486,8 @@ export default function rasterLayerPolyMixin(_layer) {
       }
     }
 
+    const mark = state.mark || {}
+
     const marks = [
       {
         type: "polys",
@@ -500,14 +502,14 @@ export default function rasterLayerPolyMixin(_layer) {
             field: "y"
           },
           fillColor,
-          strokeColor:
-            typeof state.mark === "object" ? state.mark.strokeColor : "white",
-          strokeWidth:
-            typeof state.mark === "object" ? state.mark.strokeWidth : 0.5,
-          lineJoin:
-            typeof state.mark === "object" ? state.mark.lineJoin : "miter",
-          miterLimit:
-            typeof state.mark === "object" ? state.mark.miterLimit : 10
+          /* 
+            "fillColor" is a special keyword to set strokeColor the same as fillColor
+            otherwise it will be strokeColor or white
+          */
+          strokeColor:  mark.strokeColor === "fillColor" ? fillColor : (mark.strokeColor || "white"),
+          strokeWidth: state.mark.strokeWidth || 0.5,
+          lineJoin: state.mark.lineJoin || "miter",
+          miterLimit: state.mark.miterLimit || 10
         }
       }
     ]

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -506,7 +506,10 @@ export default function rasterLayerPolyMixin(_layer) {
             "fillColor" is a special keyword to set strokeColor the same as fillColor
             otherwise it will be strokeColor or white
           */
-          strokeColor:  mark.strokeColor === "fillColor" ? fillColor : (mark.strokeColor || "white"),
+          strokeColor:
+            mark.strokeColor === "fillColor"
+              ? fillColor
+              : mark.strokeColor || "white",
           strokeWidth: mark.strokeWidth || 0,
           lineJoin: mark.lineJoin || "miter",
           miterLimit: mark.miterLimit || 10

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -507,9 +507,9 @@ export default function rasterLayerPolyMixin(_layer) {
             otherwise it will be strokeColor or white
           */
           strokeColor:  mark.strokeColor === "fillColor" ? fillColor : (mark.strokeColor || "white"),
-          strokeWidth: state.mark.strokeWidth || 0.5,
-          lineJoin: state.mark.lineJoin || "miter",
-          miterLimit: state.mark.miterLimit || 10
+          strokeWidth: mark.strokeWidth || 0,
+          lineJoin: mark.lineJoin || "miter",
+          miterLimit: mark.miterLimit || 10
         }
       }
     ]

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -486,7 +486,14 @@ export default function rasterLayerPolyMixin(_layer) {
       }
     }
 
-    const mark = state.mark || {}
+    const defaultMarkOptions = {
+      strokeColor: "white",
+      lineJoin: "miter",
+      miterLimit: 10,
+      strokeWidth: 0
+    }
+    const mark =
+      typeof state.mark === "object" ? state.mark : defaultMarkOptions
 
     const marks = [
       {
@@ -507,12 +514,10 @@ export default function rasterLayerPolyMixin(_layer) {
             otherwise it will be strokeColor or white
           */
           strokeColor:
-            mark.strokeColor === "fillColor"
-              ? fillColor
-              : mark.strokeColor || "white",
-          strokeWidth: mark.strokeWidth || 0,
-          lineJoin: mark.lineJoin || "miter",
-          miterLimit: mark.miterLimit || 10
+            mark.strokeColor === "fillColor" ? fillColor : mark.strokeColor,
+          strokeWidth: mark.strokeWidth,
+          lineJoin: mark.lineJoin,
+          miterLimit: mark.miterLimit
         }
       }
     ]


### PR DESCRIPTION
Adding the special `strokeColor: "fillColor"` to make the stroke color teh same as the fill color