### PR TITLE
[FE-10953] [FE-10954] Change uniqueId to be random instead of incrementing

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -5925,9 +5925,8 @@ utils.clamp = function (val, min, max) {
   return val < min ? min : val > max ? max : val;
 };
 
-var _idCounter = 0;
 utils.uniqueId = function () {
-  return ++_idCounter;
+  return Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
 };
 
 utils.nameToId = function (name) {

--- a/src/mixins/base-mixin.js
+++ b/src/mixins/base-mixin.js
@@ -46,7 +46,6 @@ import spinnerMixin from "../mixins/spinner-mixin"
  * @return {dc.baseMixin}
  */
 export default function baseMixin(_chart) {
-  
   // This is intended to be random every time a chart is created, but then to
   // stay that same random number for as long as the chart exists in memory.
   //

--- a/src/mixins/base-mixin.js
+++ b/src/mixins/base-mixin.js
@@ -46,6 +46,14 @@ import spinnerMixin from "../mixins/spinner-mixin"
  * @return {dc.baseMixin}
  */
 export default function baseMixin(_chart) {
+  
+  // This is intended to be random every time a chart is created, but then to
+  // stay that same random number for as long as the chart exists in memory.
+  //
+  // The main reason for this is to support the raster chart and mixins, where
+  // the renderVega and getResultRowForPixel methods to mapd-connector (.con())
+  // expect to get a integer id unique to a given active rendered chart, and
+  // the same for that chart across its active lifetime.
   _chart.__dcFlag__ = utils.uniqueId()
 
   let _dimension

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -332,9 +332,8 @@ utils.clamp = function(val, min, max) {
   return val < min ? min : val > max ? max : val
 }
 
-let _idCounter = 0
 utils.uniqueId = function() {
-  return ++_idCounter
+  return Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)
 }
 
 utils.nameToId = function(name) {


### PR DESCRIPTION
Change uniqueId to be random, to ensure charts have unique ids in the same context but across instances