### PR TITLE
[FE-10971] - naturally, if a histogram is NOT binned, it's a scalar

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -5836,9 +5836,9 @@ var getKeyValues = function getKeyValues(data) {
     return k.indexOf("key") === 0;
   });
   return keys.reduce(function (aggregate, k) {
-    return aggregate.concat(data[k].map(function (v) {
+    return aggregate.concat(Array.isArray(data[k]) ? data[k].map(function (v) {
       return typeof v === "number" ? v : v.value;
-    }));
+    }) : [data[k]]);
   }, []);
 };
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -239,7 +239,11 @@ const getKeyValues = data => {
   const keys = Object.keys(data).filter(k => k.indexOf("key") === 0)
   return keys.reduce(
     (aggregate, k) =>
-      aggregate.concat(data[k].map(v => (typeof v === "number" ? v : v.value))),
+      aggregate.concat(
+        Array.isArray(data[k])
+          ? data[k].map(v => (typeof v === "number" ? v : v.value))
+          : [data[k]]
+      ),
     []
   )
 }


### PR DESCRIPTION
Same fix as for FE-10563 with the binned histograms.

EXCEPT that if you create a histogram that is _not_binned, the data value contains a scalar and not an array. So this just wraps the access of that key with an isArray check. If it is one, then we proceed as before. If not, then we return the value wrapped in an array.

Should resolve it, as long as there aren't more cases, of course.

Repro steps in the ticket, but the short version is just to create a histogram w/o bins and ensure that you don't get an error `e[n].map is not a function`