### PR TITLE
[FE-11503] call getFilterString with name

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -54221,7 +54221,7 @@ function rasterLayerPointMixin(_layer) {
     _vega = _layer.__genVega({
       layerName: layerName,
       table: _layer.crossfilter().getTable()[0],
-      filter: _layer.crossfilter().getFilterString(),
+      filter: _layer.crossfilter().getFilterString(layerName),
       globalFilter: _layer.crossfilter().getGlobalFilterString(),
       lastFilteredSize: (0, _coreAsync.lastFilteredSize)(_layer.crossfilter().getId()),
       pixelRatio: chart._getPixelRatio()
@@ -88939,7 +88939,7 @@ function rasterLayerLineMixin(_layer) {
     _vega = _layer.__genVega({
       layerName: layerName,
       table: _layer.crossfilter().getTable()[0],
-      filter: _layer.crossfilter().getFilterString(),
+      filter: _layer.crossfilter().getFilterString(layerName),
       globalFilter: _layer.crossfilter().getGlobalFilterString(),
       lastFilteredSize: (0, _coreAsync.lastFilteredSize)(_layer.crossfilter().getId()),
       pixelRatio: chart._getPixelRatio(),

--- a/src/mixins/raster-layer-line-mixin.js
+++ b/src/mixins/raster-layer-line-mixin.js
@@ -463,7 +463,7 @@ export default function rasterLayerLineMixin(_layer) {
     _vega = _layer.__genVega({
       layerName,
       table: _layer.crossfilter().getTable()[0],
-      filter: _layer.crossfilter().getFilterString(),
+      filter: _layer.crossfilter().getFilterString(layerName),
       globalFilter: _layer.crossfilter().getGlobalFilterString(),
       lastFilteredSize: lastFilteredSize(_layer.crossfilter().getId()),
       pixelRatio: chart._getPixelRatio(),

--- a/src/mixins/raster-layer-point-mixin.js
+++ b/src/mixins/raster-layer-point-mixin.js
@@ -570,7 +570,7 @@ export default function rasterLayerPointMixin(_layer) {
     _vega = _layer.__genVega({
       layerName,
       table: _layer.crossfilter().getTable()[0],
-      filter: _layer.crossfilter().getFilterString(),
+      filter: _layer.crossfilter().getFilterString(layerName),
       globalFilter: _layer.crossfilter().getGlobalFilterString(),
       lastFilteredSize: lastFilteredSize(_layer.crossfilter().getId()),
       pixelRatio: chart._getPixelRatio()


### PR DESCRIPTION
Pretty small PR to support bigger work for FE-11503, just ensures that the layerName is handed through when getFilterString is called, since OmniCrossFilter is now aware of it and can hand back appropriately layer scoped filters from it.