### PR TITLE
[FE-11585] fixed event loop

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -34685,8 +34685,6 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
-function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
-
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
 
 /* istanbul ignore next */
@@ -34732,31 +34730,6 @@ function createUnlikelyStmtFromShape(shape, xAttr, yAttr, useLonLat) {
 
 /* istanbul ignore next */
 function rasterDrawMixin(chart) {
-  var drawEventHandler = function () {
-    var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee() {
-      return regeneratorRuntime.wrap(function _callee$(_context) {
-        while (1) {
-          switch (_context.prev = _context.next) {
-            case 0:
-              _context.next = 2;
-              return applyFilter();
-
-            case 2:
-              (0, _coreAsync.redrawAllAsync)(chart.chartGroup());
-
-            case 3:
-            case "end":
-              return _context.stop();
-          }
-        }
-      }, _callee, this);
-    }));
-
-    return function drawEventHandler() {
-      return _ref.apply(this, arguments);
-    };
-  }();
-
   var drawEngine = null;
   var buttonController = null;
   var currXRange = null;
@@ -35030,6 +35003,13 @@ function rasterDrawMixin(chart) {
     });
 
     return chart._invokeFilteredListener(chart.filters(), false);
+  }
+
+  function drawEventHandler() {
+    applyFilter();
+    setTimeout(function () {
+      return (0, _coreAsync.redrawAllAsync)(chart.chartGroup());
+    });
   }
 
   var debounceRedraw = chart.debounce(function () {

--- a/src/mixins/raster-draw-mixin.js
+++ b/src/mixins/raster-draw-mixin.js
@@ -409,7 +409,7 @@ export function rasterDrawMixin(chart) {
 
   function drawEventHandler() {
     applyFilter()
-    redrawAllAsync(chart.chartGroup())
+    setTimeout(() => redrawAllAsync(chart.chartGroup()))
   }
 
   const debounceRedraw = chart.debounce(() => {


### PR DESCRIPTION
I'm furious about this one.

Right as I was trying to merge in my very very last PR, I see build errors. Turns out I can't include an async function. No problem! I switch it to a .then() statement.

That doesn't work - the function isn't returning a promise. "That's weird," I think. Oh well, I must've put it in over-zealously.

Nope! The await there was triggering a break in the event loop, so it'd apply filters, break out, then return and run the next line. It was a bogus hidden setTimeout() line.

And the effect of this was that the count chart didn't update when you drew a lasso.

So I restored it via a setTimeout. Bah.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
