### PR TITLE
[FE-11658] - hacked up mapd-table

### DIFF
--- a/src/charts/mapd-table.js
+++ b/src/charts/mapd-table.js
@@ -364,10 +364,21 @@ export default function mapdTable(parent, chartGroup) {
           if (_isGroupedData) {
             _chart.onClick(d)
           } else if (col.expression in _filteredColumns) {
-            clearColFilter(col.expression)
+            delete _columnFilterMap[col.expression]
+            // this doesn't work. It ~never~ worked.
+            // const filterArray = cols.map(c => _columnFilterMap[c.expression])
+            const filterArray = []
+            _chart.removeFilteredColumn(col.expression)
+            if (filterArray.some(f => f !== undefined && f !== null)) {
+              _chart.onClick(filterArray) // will update global filter Clear icon
+            } else {
+              _chart.filterAll()
+            }
+            redrawAllAsync(_chart.chartGroup())
           } else {
             filterCol(col.expression, d[col.name])
-            _chart.onClick(d[col.name]) // will update global filter Clear icon
+            const filterArray = cols.map(c => _columnFilterMap[c.expression])
+            _chart.onClick(filterArray) // will update global filter Clear icon
           }
         })
     })
@@ -513,8 +524,6 @@ export default function mapdTable(parent, chartGroup) {
     } else if (type === "DATE") {
       const dateFormat = d3.time.format.utc("%Y-%m-%d")
       val = "DATE '" + dateFormat(val) + "'"
-    } else if (val && typeof val === "string") {
-      val = "'" + val.replace(/'/g, "''") + "'"
     }
 
     _chart.addFilteredColumn(expr)

--- a/src/mixins/filter-mixin.js
+++ b/src/mixins/filter-mixin.js
@@ -67,26 +67,12 @@ export function filterHandlerWithChartContext(_chart) {
       if (_chart.clearTableFilter) {
         _chart.clearTableFilter() // global filter also will clear all the columns filters on the table
       }
-    } else if (_chart.hasOwnProperty("rangeFocused")) {
-      dimension.filterMulti(
-        filters,
-        _chart.rangeFocused(),
-        _chart.filtersInverse(),
-        _chart.group().binParams()
-      )
     } else if (
       _chart.getFilteredColumns &&
       Object.keys(_chart.getFilteredColumns()).length > 0
     ) {
       // case for column filtering on measures
       return filters
-    } else {
-      dimension.filterMulti(
-        filters,
-        undefined,
-        _chart.filtersInverse(),
-        _chart.group().binParams()
-      ) // eslint-disable-line no-undefined
     }
     return filters
   }


### PR DESCRIPTION
Filters on non-grouped tables _do not work_.

This makes them work _better_.

You'd once again be able to click on a column to filter on it, including multiple filters. Clearing any one of those filters clears all the filters (as it always worked).

A table can now be loaded with a saved filter, and it will display "correctly" in that the data is filtered, but it will _not_ have the blue highlighting unless the filter is re-applied.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
