### PR TITLE
[FE-11870] Update axis/chart control colors to #868686

### DIFF
--- a/dist/mapdc.css
+++ b/dist/mapdc.css
@@ -396,10 +396,11 @@ body {
 .open-toggle {
   cursor: pointer; }
 
-.nominal-legend.legendables {
+.legendables.nominal-legend {
   border: 1px solid #e2e2e2 !important; }
-  .nominal-legend.legendables .header {
-    font-weight: normal; }
+
+.legendables .header {
+  font-weight: normal; }
 
 .anim-button-play, .anim-button-stop {
   z-index: 2;

--- a/dist/mapdc.css
+++ b/dist/mapdc.css
@@ -414,7 +414,7 @@ body {
     background: white !important; }
   .anim-button-play .fa, .anim-button-stop .fa {
     font-size: 13px !important;
-    color: #a7a7a7 !important;
+    color: #868686 !important;
     position: relative;
     top: -1px; }
 
@@ -558,7 +558,7 @@ body {
     .dc-chart .range-display:hover input {
       border: 1px solid #c7c7c7; }
   .dc-chart .axis {
-    fill: #a7a7a7; }
+    fill: #868686; }
     .dc-chart .axis text {
       font-family: "Roboto"; }
     .dc-chart .axis path, .dc-chart .axis line {
@@ -609,13 +609,13 @@ body {
     .dc-chart g.deselected:not(.pie-slice.all-others) path:hover {
       fill: #e2e2e2; }
     .dc-chart g.deselected:not(.pie-slice.all-others) path text {
-      fill-opacity: #a7a7a7; }
+      fill-opacity: #868686; }
   .dc-chart text.deselected-label {
     fill: #868686 !important; }
   .dc-chart div.x-axis-label, .dc-chart div.y-axis-label, .dc-chart div.axis-label-edit {
     position: absolute;
     font-size: 13px !important;
-    color: #a7a7a7;
+    color: #868686;
     z-index: 2;
     pointer-events: none;
     height: 18px;
@@ -656,7 +656,7 @@ body {
       left: 0;
       cursor: text;
       width: 100%;
-      color: #a7a7a7;
+      color: #868686;
       outline: none;
       text-align: center;
       opacity: 0;
@@ -708,7 +708,7 @@ body {
     .dc-chart .external-axis .axis path, .dc-chart .external-axis .axis line {
       stroke: #c7c7c7 !important; }
     .dc-chart .external-axis .axis text {
-      fill: #a7a7a7 !important; }
+      fill: #868686 !important; }
   .dc-chart .md-table-wrapper {
     padding: 0;
     overflow: hidden;
@@ -741,7 +741,7 @@ body {
     .dc-chart .md-table-wrapper tr.deselected {
       background: #f5f5f5; }
       .dc-chart .md-table-wrapper tr.deselected td {
-        color: #a7a7a7; }
+        color: #868686; }
     .dc-chart .md-table-wrapper tr.grouped-data:hover td {
       color: #22A7F0; }
   .dc-chart .md-header-spacer {
@@ -1068,7 +1068,7 @@ body {
     border-radius: 50%; }
   .chart-popup th {
     border-bottom: 1px solid #e2e2e2;
-    color: #a7a7a7;
+    color: #868686;
     font-size: 0.84em;
     font-weight: normal;
     background: white; }
@@ -1178,7 +1178,7 @@ body {
     font-weight: bold; }
   .chart-popup .popup-header {
     border-bottom: 1px solid #e2e2e2;
-    color: #a7a7a7;
+    color: #868686;
     font-size: 0.77em;
     white-space: nowrap;
     padding: 4px 4px 2px 4px; }
@@ -1281,7 +1281,7 @@ body {
         font-size: 12px; }
   .legend-cont .legend-title {
     font-size: 12px;
-    color: #a7a7a7;
+    color: #868686;
     font-weight: bold;
     text-align: center;
     position: absolute;
@@ -1315,7 +1315,7 @@ body {
         display: none; }
 
 .svg-icon {
-  fill: #a7a7a7; }
+  fill: #868686; }
 
 .map-svg {
   left: 0;
@@ -1340,7 +1340,7 @@ body {
       background-color: rgba(0, 0, 0, 0.4); }
   .dc-legend .dc-legend-header {
     border-bottom: 1px solid #e2e2e2;
-    color: #a7a7a7;
+    color: #868686;
     font-size: 0.84em;
     margin: 4px 4px 0 4px;
     position: relative;
@@ -1365,15 +1365,15 @@ body {
       left: 50%;
       width: 4px;
       height: 24px;
-      background: #a7a7a7; }
+      background: #868686; }
     .dc-legend .toggle-btn:before {
       width: 16px;
       height: 16px;
       bottom: 0;
       left: 0;
       border: 8px solid transparent;
-      border-left-color: #a7a7a7;
-      border-bottom-color: #a7a7a7; }
+      border-left-color: #868686;
+      border-bottom-color: #868686; }
     .dc-legend .toggle-btn:hover:after {
       background: #22A7F0; }
     .dc-legend .toggle-btn:hover:before {
@@ -1482,7 +1482,7 @@ body {
       left: -16px; }
     .heatmap-scroll .docked-x-axis .rotate-up:after {
       border: 6px solid transparent;
-      border-left-color: #a7a7a7;
+      border-left-color: #868686;
       position: absolute;
       content: "";
       left: -8px;
@@ -1509,7 +1509,7 @@ body {
   position: absolute;
   line-height: 1;
   font-size: 10px;
-  color: #a7a7a7;
+  color: #868686;
   white-space: nowrap;
   padding: 4px;
   pointer-events: auto;

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -89955,7 +89955,7 @@ function legendMixin(legend) {
       var itemEnter = body.selectAll(".dc-legend-item").data(legendables).enter().append("div").attr("class", "dc-legend-item");
 
       itemEnter.append("div").attr("class", "legend-item-color").style("background", function (d) {
-        return d ? d.color : "#a7a7a7";
+        return d ? d.color : "#868686";
       });
 
       itemEnter.append("div").attr("class", "legend-item-text").text(function (d) {

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -29,8 +29,10 @@ body {
     cursor: pointer;
 }
 
-.nominal-legend.legendables {
-    border: 1px solid $gray2 !important;
+.legendables {
+    &.nominal-legend {
+        border: 1px solid $gray2 !important;
+    }
 
     .header {
         font-weight: normal;

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -53,7 +53,7 @@ body {
 
     .fa {
         font-size: 13px !important;
-        color: $gray4 !important;
+        color: $text-gray !important;
         position: relative;
         top: -1px;
     }
@@ -304,7 +304,7 @@ body {
 
     .axis {
 
-        fill: $gray4;
+        fill: $text-gray;
 
         text {
             font-family: "Roboto";
@@ -405,7 +405,7 @@ body {
         }
 
         text {
-            fill-opacity: $gray4;
+            fill-opacity: $text-gray;
         }
     }
 
@@ -416,7 +416,7 @@ body {
     div.x-axis-label, div.y-axis-label, div.axis-label-edit {
         position: absolute;
         font-size: 13px !important;
-        color: $gray4;
+        color: $text-gray;
         z-index: 2;
         pointer-events: none;
         height: 18px;
@@ -469,7 +469,7 @@ body {
             left: 0;
             cursor: text;
             width: 100%;
-            color: $gray4;
+            color: $text-gray;
             outline: none;
             text-align: center;
             opacity: 0;
@@ -543,7 +543,7 @@ body {
             }
 
             text {
-                fill: $gray4 !important;
+                fill: $text-gray !important;
             }
         }
     }
@@ -597,7 +597,7 @@ body {
             &.deselected {
                 background: $gray1;
                 td {
-                    color: $gray4;
+                    color: $text-gray;
                 }
             }
 
@@ -1134,7 +1134,7 @@ body {
 
     th {
         border-bottom: 1px solid $gray2;
-        color: $gray4;
+        color: $text-gray;
         font-size: 0.84em;
         font-weight: normal;
         background: white;
@@ -1317,7 +1317,7 @@ body {
 
     .popup-header {
         border-bottom: 1px solid $gray2;
-        color: $gray4;
+        color: $text-gray;
         font-size: 0.77em;
         white-space: nowrap;
         padding: 4px 4px 2px 4px;
@@ -1487,7 +1487,7 @@ body {
 
     .legend-title {
         font-size: 12px;
-        color: $gray4;
+        color: $text-gray;
         font-weight: bold;
         text-align: center;
         position: absolute;
@@ -1540,7 +1540,7 @@ body {
 }
 
 .svg-icon {
-    fill: $gray4;
+    fill: $text-gray;
 }
 
 .map-svg {
@@ -1576,7 +1576,7 @@ body {
 
     .dc-legend-header {
         border-bottom: 1px solid $gray2;
-        color: $gray4;
+        color: $text-gray;
         font-size: 0.84em;
         margin: 4px 4px 0 4px;
         position: relative;
@@ -1606,7 +1606,7 @@ body {
             left: 50%;
             width: 4px;
             height: 24px;
-            background: $gray4;
+            background: $text-gray;
         }
 
         &:before {
@@ -1615,8 +1615,8 @@ body {
             bottom: 0;
             left: 0;
             border: 8px solid transparent;
-            border-left-color: $gray4;
-            border-bottom-color: $gray4;
+            border-left-color: $text-gray;
+            border-bottom-color: $text-gray;
         }
 
         &:hover {
@@ -1774,7 +1774,7 @@ body {
 
             &:after {
                 border: 6px solid transparent;
-                border-left-color: $gray4;
+                border-left-color: $text-gray;
                 position: absolute;
                 content: "";
                 left: -8px;
@@ -1818,7 +1818,7 @@ body {
         position: absolute;
         line-height: 1;
         font-size: 10px;
-        color: $gray4;
+        color: $text-gray;
         white-space: nowrap;
         padding: 4px;
         pointer-events: auto;

--- a/src/mixins/dc-legend-mixin.js
+++ b/src/mixins/dc-legend-mixin.js
@@ -63,7 +63,7 @@ export default function legendMixin(legend) {
       itemEnter
         .append("div")
         .attr("class", "legend-item-color")
-        .style("background", d => (d ? d.color : "#a7a7a7"))
+        .style("background", d => (d ? d.color : "#868686"))
 
       itemEnter
         .append("div")


### PR DESCRIPTION
We're updating light mode chart axis colors across the board from #aaa/#a7a7a7 etc to #868686 (which is $text-gray in Immerse)

https://omnisci.atlassian.net/browse/FE-11870

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
