### PR TITLE
[FE-11967] :bug: test for domains with cnt(NULL) > 1

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -79376,7 +79376,10 @@ function toLegendState() {
 }
 
 function isNullLegend(domain) {
-  return _.includes(domain, "NULL");
+  // only return true if there is more than one "NULL" value
+  return domain.reduce(function (cnt, d) {
+    return d === "NULL" ? cnt + 1 : cnt;
+  }, 0) > 1;
 }
 
 /***/ }),

--- a/src/chart-addons/stacked-legend.js
+++ b/src/chart-addons/stacked-legend.js
@@ -331,5 +331,6 @@ export function toLegendState(states = [], chart, useMap) {
 }
 
 function isNullLegend(domain) {
-  return _.includes(domain, "NULL")
+  // only return true if there is more than one "NULL" value
+  return domain.reduce((cnt, d) => (d === "NULL" ? cnt + 1 : cnt), 0) > 1
 }


### PR DESCRIPTION
PR #270 added a fix for domains that look like `["NULL", "NULL"]` - however, that fix was applying to any domain that included "NULL". This fix just tests for domains that have "NULL" more than once.

Fixes [FE-11967](https://omnisci.atlassian.net/browse/FE-11967)