### PR TITLE
[FE-11589] - enable shift to zoom functionality

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -34361,7 +34361,33 @@ function mapMixin(_chart, chartDivId, _mapboxgl) {
     initMouseLatLonCoordinate();
   }
 
+  // if shiftToZoom is enabled, then we've added an event handler on mouseDown.
+  // if we click while holding shift, then enable the zoom/pan handlers. And if not,
+  // disable them.
+  //
+  // and why don't we just do it in the move handler? Because once we've disabled drag, we need
+  // a way to re-enable it. Ideally, we'd just stop the event from firing the default actions, but
+  // that doesn't seem to handle it. So here we are.
+  function onMouseDownCheckForShiftToZoom(e) {
+    if (!e.originalEvent.shiftKey) {
+      _map.scrollZoom.disable();
+      _map.dragPan.disable();
+    } else {
+      _map.scrollZoom.enable();
+      _map.dragPan.enable();
+    }
+  }
+
   function onMapMove(e) {
+    if (_chart.shiftToZoom() && (e.originalEvent && !e.originalEvent.shiftKey || e.type === "moveend")) {
+      _map.scrollZoom.disable();
+      _map.dragPan.disable();
+      return;
+    } else {
+      _map.dragPan.enable();
+      _map.scrollZoom.enable();
+    }
+
     if (e.type === "moveend" && _lastMapMoveType === "moveend" || !_hasRendered || e.skipRedraw) {
       return;
     }
@@ -34379,7 +34405,7 @@ function mapMixin(_chart, chartDivId, _mapboxgl) {
       _chart._maxCoord = [bounds._ne.lng, bounds._ne.lat];
     }
 
-    if (e.type === "move") {
+    if (e.type !== "moveend") {
       if (_isFirstMoveEvent) {
         _lastMapUpdateTime = curTime;
         _isFirstMoveEvent = false;
@@ -34666,12 +34692,25 @@ function mapMixin(_chart, chartDivId, _mapboxgl) {
     _chart.addMapListeners();
     _mapInitted = true;
     _chart.enableInteractions(_interactionsEnabled);
+    if (_chart.shiftToZoom()) {
+      _map.on("mousedown", onMouseDownCheckForShiftToZoom);
+      _map.boxZoom.disable();
+    }
   }
 
   _chart.addMapListeners = function () {
-    _map.on("move", onMapMove);
     _map.on("moveend", onMapMove);
     _map.on("sourcedata", showMapLogo);
+    // if we're using shiftToZoom, then add on explicit drag/wheel events.
+    // otherwise, do it as we did before with a single "move"
+    //
+    // we need the separate wheel event so we can hop in and disable it from within the handler
+    if (_chart.shiftToZoom()) {
+      _map.on("drag", onMapMove);
+      _map.on("wheel", onMapMove);
+    } else {
+      _map.on("move", onMapMove);
+    }
   };
 
   _chart.removeMapListeners = function () {
@@ -78451,6 +78490,8 @@ function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
   var _popupDisplayable = true;
   var _legendOpen = true;
 
+  var _shiftToZoom = false;
+
   _chart.legendOpen = function (_) {
     if (!arguments.length) {
       return _legendOpen;
@@ -78637,6 +78678,13 @@ function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
         layer.setSample();
       }
     });
+  };
+
+  _chart.shiftToZoom = function (shiftToZoom) {
+    if (shiftToZoom !== undefined) {
+      _shiftToZoom = shiftToZoom;
+    }
+    return _shiftToZoom;
   };
 
   function getCountFromBoundingBox(chart, _layer) {
@@ -79918,6 +79966,10 @@ var ScrollZoomHandler = function (_BaseHandler2) {
   }, {
     key: "_wheelZoom",
     value: function _wheelZoom(doFullRender, delta, e) {
+      if (this._chart.shiftToZoom() && e && !e.shiftKey) {
+        return;
+      }
+
       if (!doFullRender && delta === 0 || !this._chart.elasticX() || !this._chart.elasticY()) {
         return;
       }
@@ -80225,6 +80277,9 @@ var DragPanHandler = function (_BaseHandler3) {
   }, {
     key: "_ignoreEvent",
     value: function _ignoreEvent(e) {
+      if (this._chart.shiftToZoom() && e && !e.shiftKey) {
+        return true;
+      }
       var map = this._chart.map();
       if (map.boxZoom && map.boxZoom.isActive()) {
         return true;
@@ -80439,9 +80494,11 @@ function bindEventHandlers(chart, container, dataBounds, dataScale, dataOffset, 
     });
   }
 
-  function enableInteractionsInternal() {
+  function enableInteractionsInternal(shiftToZoom) {
     map.scrollZoom.enable();
-    map.boxZoom.enable();
+    if (!shiftToZoom) {
+      map.boxZoom.enable();
+    }
     // NOTE: box zoom must be enabled before dragPan
     map.dragPan.enable();
   }
@@ -80453,8 +80510,8 @@ function bindEventHandlers(chart, container, dataBounds, dataScale, dataOffset, 
   }
 
   var rtn = {
-    enableInteractions: function enableInteractions() {
-      enableInteractionsInternal();
+    enableInteractions: function enableInteractions(shiftToZoom) {
+      enableInteractionsInternal(shiftToZoom);
     },
 
     disableInteractions: function disableInteractions() {
@@ -80472,7 +80529,7 @@ function bindEventHandlers(chart, container, dataBounds, dataScale, dataOffset, 
   };
 
   if (enableInteractions) {
-    rtn.enableInteractions();
+    rtn.enableInteractions(chart.shiftToZoom());
   }
 
   return rtn;

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -78,6 +78,8 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
   let _popupDisplayable = true
   let _legendOpen = true
 
+  let _shiftToZoom = false
+
   _chart.legendOpen = function(_) {
     if (!arguments.length) {
       return _legendOpen
@@ -262,6 +264,13 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
         layer.setSample()
       }
     })
+  }
+
+  _chart.shiftToZoom = function(shiftToZoom) {
+    if (shiftToZoom !== undefined) {
+      _shiftToZoom = shiftToZoom
+    }
+    return _shiftToZoom
   }
 
   function getCountFromBoundingBox(chart, _layer) {

--- a/src/mixins/ui/coordinate-grid-raster-mixin-ui.js
+++ b/src/mixins/ui/coordinate-grid-raster-mixin-ui.js
@@ -538,6 +538,10 @@ class ScrollZoomHandler extends BaseHandler {
   }
 
   _wheelZoom(doFullRender, delta, e) {
+    if (this._chart.shiftToZoom() && e && !e.shiftKey) {
+      return
+    }
+
     if (
       (!doFullRender && delta === 0) ||
       (!this._chart.elasticX() || !this._chart.elasticY())
@@ -857,6 +861,9 @@ class DragPanHandler extends BaseHandler {
   }
 
   _ignoreEvent(e) {
+    if (this._chart.shiftToZoom() && e && !e.shiftKey) {
+      return true
+    }
     const map = this._chart.map()
     if (map.boxZoom && map.boxZoom.isActive()) {
       return true
@@ -1122,9 +1129,11 @@ export default function bindEventHandlers(
     })
   }
 
-  function enableInteractionsInternal() {
+  function enableInteractionsInternal(shiftToZoom) {
     map.scrollZoom.enable()
-    map.boxZoom.enable()
+    if (!shiftToZoom) {
+      map.boxZoom.enable()
+    }
     // NOTE: box zoom must be enabled before dragPan
     map.dragPan.enable()
   }
@@ -1136,8 +1145,8 @@ export default function bindEventHandlers(
   }
 
   const rtn = {
-    enableInteractions: () => {
-      enableInteractionsInternal()
+    enableInteractions: shiftToZoom => {
+      enableInteractionsInternal(shiftToZoom)
     },
 
     disableInteractions: () => {
@@ -1153,7 +1162,7 @@ export default function bindEventHandlers(
   }
 
   if (enableInteractions) {
-    rtn.enableInteractions()
+    rtn.enableInteractions(chart.shiftToZoom())
   }
 
   return rtn


### PR DESCRIPTION
The mods to maps-charting to enable shift-to-zoom.

I felt like I needed to hack up the mapbox interface a bit to do this and would've hoped there was a better way to do it. Definitely open to suggestions if there's a simpler way to enable modifier keys during interactions, but all I could find was explicitly turning the zoom/pan handlers off/on based upon the event having the shiftKey. :-(

Also needed to explicitly break it apart and add a wheel event, since otherwise it's a shift click that restores the handler. It's messy.