### PR TITLE
[FE-11974] [FE-11924] Axis min/max input - use auto height

### DIFF
--- a/dist/mapdc.css
+++ b/dist/mapdc.css
@@ -679,7 +679,7 @@ body {
       outline: none;
       text-align: center;
       opacity: 0;
-      height: 20px; }
+      height: auto; }
       .dc-chart div.axis-label-edit input:focus {
         opacity: 1; }
       .dc-chart div.axis-label-edit input:placeholder {
@@ -1745,7 +1745,7 @@ body {
     transform: translateY(-50%); }
   .axis-lock input {
     display: block;
-    height: 14px;
+    height: auto;
     font-size: 10px;
     padding: 0;
     position: absolute;
@@ -1755,7 +1755,7 @@ body {
     z-index: 1;
     outline: none; }
     .axis-lock input:focus {
-      height: 24px;
+      height: auto;
       font-size: 12px; }
       .axis-lock input:focus + div {
         font-size: 12px;

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -497,7 +497,7 @@ body {
             outline: none;
             text-align: center;
             opacity: 0;
-            height: 20px;
+            height: auto;
 
             &:focus {
                 opacity: 1;

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -2166,7 +2166,7 @@ body {
 
     input {
         display: block;
-        height: 14px;
+        height: auto;
         font-size: 10px;
         padding: 0;
         position: absolute;
@@ -2177,7 +2177,7 @@ body {
         outline: none;
 
         &:focus {
-            height: 24px;
+            height: auto;
             font-size: 12px;
 
             & + div {


### PR DESCRIPTION
Now that we allow users to change the font size of axis labels, make sure input heights adjust accordingly

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
