### PR TITLE
[FE-12147] Auto-resize height of legend input

### DIFF
--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -1490,7 +1490,7 @@ body {
         pointer-events: auto;
 
         input {
-            height: 16px;
+            height: auto;
             width: 32px;
             min-width: 32px;
             border: 1px solid $gray3;


### PR DESCRIPTION


![Screen Shot 2020-08-20 at 8 46 01 AM](https://user-images.githubusercontent.com/1165936/90794390-997ea200-e2c1-11ea-9f7f-308c702e8298.png)


# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
