### PR TITLE
[FE-12062] interaction prop names

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -80325,6 +80325,8 @@ var DragPanHandler = function (_BaseHandler3) {
 
 
 function bindEventHandlers(chart, container, dataBounds, dataScale, dataOffset, filterDimensionsCB, chartRedrawCB, browser, mapboxglModule, enableInteractions) {
+  var _this6 = this;
+
   var map = chart.map();
   var startPos = null;
   var tapped = null;
@@ -80532,7 +80534,7 @@ function bindEventHandlers(chart, container, dataBounds, dataScale, dataOffset, 
     },
 
     getInteractionPropNames: function getInteractionPropNames() {
-      return ["scrollZoom", "boxZoom", "dragPan"];
+      return _this6.shiftToZoom() ? ["scrollZoom", "boxZoom", "dragPan"] : ["scrollZoom", "dragPan"];
     }
   };
 

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -51266,7 +51266,7 @@ function coordinateGridRasterMixin(_chart, _mapboxgl, browser) {
     _interactionsEnabled = Boolean(enableInteractions);
     if (_eventHandler) {
       var map = _chart.map();
-      _eventHandler.getInteractionPropNames().forEach(function (prop) {
+      _eventHandler.getInteractionPropNames(_chart).forEach(function (prop) {
         if (map[prop]) {
           var enable = typeof opts[prop] === "undefined" ? _interactionsEnabled : Boolean(opts[prop]);
           if (enable) {
@@ -80325,8 +80325,6 @@ var DragPanHandler = function (_BaseHandler3) {
 
 
 function bindEventHandlers(chart, container, dataBounds, dataScale, dataOffset, filterDimensionsCB, chartRedrawCB, browser, mapboxglModule, enableInteractions) {
-  var _this6 = this;
-
   var map = chart.map();
   var startPos = null;
   var tapped = null;
@@ -80533,8 +80531,8 @@ function bindEventHandlers(chart, container, dataBounds, dataScale, dataOffset, 
       disableInteractionsInternal();
     },
 
-    getInteractionPropNames: function getInteractionPropNames() {
-      return _this6.shiftToZoom() ? ["scrollZoom", "boxZoom", "dragPan"] : ["scrollZoom", "dragPan"];
+    getInteractionPropNames: function getInteractionPropNames(chart) {
+      return chart.shiftToZoom() ? ["scrollZoom", "dragPan"] : ["scrollZoom", "boxZoom", "dragPan"];
     }
   };
 

--- a/src/mixins/coordinate-grid-raster-mixin.js
+++ b/src/mixins/coordinate-grid-raster-mixin.js
@@ -221,7 +221,7 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
     _interactionsEnabled = Boolean(enableInteractions)
     if (_eventHandler) {
       const map = _chart.map()
-      _eventHandler.getInteractionPropNames().forEach(prop => {
+      _eventHandler.getInteractionPropNames(_chart).forEach(prop => {
         if (map[prop]) {
           const enable = (typeof opts[prop] === "undefined" ? _interactionsEnabled : Boolean(opts[prop]))
           if (enable) {

--- a/src/mixins/ui/coordinate-grid-raster-mixin-ui.js
+++ b/src/mixins/ui/coordinate-grid-raster-mixin-ui.js
@@ -1158,7 +1158,9 @@ export default function bindEventHandlers(
       disableInteractionsInternal()
     },
 
-    getInteractionPropNames: () => ["scrollZoom", "boxZoom", "dragPan"]
+    getInteractionPropNames: () => this.shiftToZoom()
+        ? ["scrollZoom", "boxZoom", "dragPan"]
+        : ["scrollZoom", "dragPan"]
   }
 
   if (enableInteractions) {

--- a/src/mixins/ui/coordinate-grid-raster-mixin-ui.js
+++ b/src/mixins/ui/coordinate-grid-raster-mixin-ui.js
@@ -1158,9 +1158,10 @@ export default function bindEventHandlers(
       disableInteractionsInternal()
     },
 
-    getInteractionPropNames: () => this.shiftToZoom()
-        ? ["scrollZoom", "boxZoom", "dragPan"]
-        : ["scrollZoom", "dragPan"]
+    getInteractionPropNames: chart =>
+      chart.shiftToZoom()
+        ? ["scrollZoom", "dragPan"]
+        : ["scrollZoom", "boxZoom", "dragPan"]
   }
 
   if (enableInteractions) {


### PR DESCRIPTION
Closes [FE-12062](https://omnisci.atlassian.net/browse/FE-12062)

This hacks the getInteractionPropNames to ensure that the draw engine doesn't re-enable boxZoom if shiftToZoom is enabled.

It _probably_ could be handled by pushing onto the array, but I opted to leave it in the middle position just in case anything cares. Of course, if anything _does_ care, the shift flavor could break. Anyway, minor stuff.

Hopefully this resolves the scatter shift-to-zoom issues.