### PR TITLE
[FE-12170] Filter poly for Data export

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -54678,7 +54678,7 @@ function rasterLayerPolyMixin(_layer) {
         });
       }
 
-      if (layerFilter.length) {
+      if (layerFilter.length && !isDataExport) {
         transforms.push({
           type: "aggregate",
           fields: [_utils.parser.parseExpression({
@@ -54693,6 +54693,15 @@ function rasterLayerPolyMixin(_layer) {
           ops: [null],
           as: ["color"],
           groupby: {}
+        });
+      } else if (layerFilter.length && isDataExport) {
+        transforms.push({
+          type: "filter",
+          expr: _utils.parser.parseExpression({
+            type: filtersInverse ? "not in" : "in",
+            expr: withAlias + ".key0",
+            set: layerFilter
+          })
         });
       }
       if (typeof filter === "string" && filter.length) {
@@ -54726,7 +54735,7 @@ function rasterLayerPolyMixin(_layer) {
           as: "color"
         });
       }
-      if (layerFilter.length) {
+      if (layerFilter.length && !isDataExport) {
         transforms.push({
           type: "project",
           expr: _utils.parser.parseExpression({
@@ -54743,6 +54752,17 @@ function rasterLayerPolyMixin(_layer) {
             else: null
           }),
           as: "color"
+        });
+      } else if (layerFilter.length && isDataExport) {
+        // For Choropleth Data Export, if we have poly selection filter, we don't need to gray out unfiltered polygons
+        // Thus, no CASE statement necessary, and we need to include the selected rowid in WHERE clause
+        transforms.push({
+          type: "filter",
+          expr: _utils.parser.parseExpression({
+            type: filtersInverse ? "not in" : "in",
+            expr: "rowid",
+            set: layerFilter
+          })
         });
       }
       if (typeof filter === "string") {


### PR DESCRIPTION
# Merge Checklist

## Description: 
When we make poly selection filter in Choropleth chart, we receive image with all polygons but colored based on filter status. Filtered polygons are colored and unfiltered polygons are grayed out. However, when we export the poly data, we only need to export the filtered polygon since there is no color information passed down to geojson file. Thus, we change the sql query to include the selected rowid in the WHERE clause.

## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #https://omnisci.atlassian.net/browse/FE-12170
## Relates with: https://github.com/omnisci/mapd-immerse/pull/7048

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
