### PR TITLE
[FE-11992] Update sampling to use new SAMPLE_RATIO function

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -58906,23 +58906,14 @@ function parseResolvefilter(sql, transform) {
 /* harmony export (immutable) */ __webpack_exports__["a"] = sample;
 
 
-var GOLDEN_RATIO = 2654435761;
-
-var THIRTY_ONE_BITS = 2147483648;
-var THIRTY_TWO_BITS = 4294967296;
-
 function sample(sql, transform) {
   var size = transform.size,
       limit = transform.limit;
 
   var ratio = Math.min(limit / size, 1.0);
-  var threshold = Math.floor(THIRTY_TWO_BITS * ratio);
-
-  // sampleTable prop is in the transform from point, poly, linestring charts
-  var samplingTable = transform.sampleTable || sql.from;
 
   if (transform.method === "multiplicativeRowid" && ratio < 1) {
-    sql.where.push("((MOD( MOD (" + samplingTable + ".rowid, " + THIRTY_ONE_BITS + ") * " + GOLDEN_RATIO + " , " + THIRTY_TWO_BITS + ") < " + threshold + ") OR (" + transform.field + " IN (" + transform.expr.map(function (e) {
+    sql.where.push("(SAMPLE_RATIO(" + ratio + ") OR (" + transform.field + " IN (" + transform.expr.map(function (e) {
       return typeof e === "string" ? "'" + e + "'" : "" + e;
     }).join(", ") + ")))");
   } else if (transform.method === "multiplicative" && ratio < 1) {
@@ -58931,7 +58922,7 @@ function sample(sql, transform) {
     // to optimize the filter here. This helps  the overflow on the backend.
     // We don't have the full modulo expression for golden ratio since 
     // that is a constant expression and we can avoid that execution
-    sql.where.push("MOD( MOD (" + samplingTable + ".rowid, " + THIRTY_ONE_BITS + ") * " + GOLDEN_RATIO + " , " + THIRTY_TWO_BITS + ") < " + threshold);
+    sql.where.push("SAMPLE_RATIO(" + ratio + ")");
   }
 
   return sql;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7849,9 +7849,9 @@
       }
     },
     "mapd-data-layer-2": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/mapd-data-layer-2/-/mapd-data-layer-2-0.0.22.tgz",
-      "integrity": "sha512-qH8AjX9rMcF2ncBchmhj0GwnckAH7rja65pdzI6PBq1BrPn2YE8ERlcDqT9EpYdVayFTTd21SeBOOGgMVhwn2Q==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/mapd-data-layer-2/-/mapd-data-layer-2-0.0.23.tgz",
+      "integrity": "sha512-CUdMc2bklToW1I+1bW7A2FGNKT/XbfcOPXFmSUHx+tWFR4kpi0aRTbjNblMuCTXU1LUCvY7o8e+5nV3mcsu4Bg==",
       "requires": {
         "invariant": "^2.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "fast-deep-equal": "^2.0.1",
     "legendables": "git://github.com/omnisci/legendables.git#63e2ad9a8375a11e5510a5dadf0b7a4326fae888",
     "mapbox-gl": "1.9.1",
-    "mapd-data-layer-2": "0.0.22",
+    "mapd-data-layer-2": "0.0.23",
     "moment": "^2.19.3",
     "ramda": "0.21.0",
     "simplify-js": "^1.2.1",

--- a/src/mixins/raster-layer-point-mixin.unit.spec.js
+++ b/src/mixins/raster-layer-point-mixin.unit.spec.js
@@ -141,7 +141,7 @@ describe("rasterLayerPointMixin", () => {
           "SELECT conv_4326_900913_x(lon) AS x, "
           + "conv_4326_900913_y(lat) AS y "
           + "FROM tweets_nov_feb "
-          + "WHERE MOD( MOD (tweets_nov_feb.rowid, 2147483648) * 2654435761 , 4294967296) < 7222804 "
+          + "WHERE SAMPLE_RATIO(0.0016816902723414068) "
           + "AND (lon = 100) LIMIT 2000000"
         )
 


### PR DESCRIPTION
Pull in metis change from https://github.com/omnisci/metis/pull/87 / 0.0.23, to use new more performant SAMPLE_RATIO function for sampling a subset of rows for render requests, instead of the MOD()-based hashing approach.

Before (both are filters in the SQL WHERE clause):
```
MOD( MOD (taxis.rowid, 2147483648) * 2654435761 , 4294967296) < 12469954
```

After:
```
SAMPLE_RATIO(0.002903387524200134)
```

The parameter to SAMPLE_RATIO is a number from 0.0-1.0 representing a probability the row will be in the results. In this case, about 0.2% of the rows will make it through. The prior MOD() sampling expression did this too, as a result of the ratio used for the rowid multiplier - so the above should be equivalent in effect.