### PR TITLE
[FE-12211] :bug: export pointmaps in 4326

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -53976,14 +53976,14 @@ function rasterLayerPointMixin(_layer) {
       if (isDataExport) {
         transforms.push({
           type: "project",
-          expr: "ST_SetSRID(ST_Point(" + AGGREGATES[x.aggregate] + "(" + x.field + "), " + AGGREGATES[y.aggregate] + "(" + y.field + ")), 900913)"
+          expr: "ST_SetSRID(ST_Point(" + AGGREGATES[x.aggregate] + "(" + x.field + "), " + AGGREGATES[y.aggregate] + "(" + y.field + ")), 4326)"
         });
       }
     } else {
       if (isDataExport) {
         transforms.push({
           type: "project",
-          expr: "/*+ cpu_mode */ ST_SetSRID(ST_Point(" + x.field + ", " + y.field + "), 900913)"
+          expr: "/*+ cpu_mode */ ST_SetSRID(ST_Point(" + x.field + ", " + y.field + "), 4326)"
         });
       } else {
         transforms.push({

--- a/src/mixins/raster-layer-point-mixin.js
+++ b/src/mixins/raster-layer-point-mixin.js
@@ -210,14 +210,14 @@ export default function rasterLayerPointMixin(_layer) {
           type: "project",
           expr: `ST_SetSRID(ST_Point(${AGGREGATES[x.aggregate]}(${x.field}), ${
             AGGREGATES[y.aggregate]
-          }(${y.field})), 900913)`
+          }(${y.field})), 4326)`
         })
       }
     } else {
       if (isDataExport) {
         transforms.push({
           type: "project",
-          expr: `/*+ cpu_mode */ ST_SetSRID(ST_Point(${x.field}, ${y.field}), 900913)`
+          expr: `/*+ cpu_mode */ ST_SetSRID(ST_Point(${x.field}, ${y.field}), 4326)`
         })
       } else {
         transforms.push({


### PR DESCRIPTION
When exporting pointmaps, we should use 4326 instead of 900913.