### PR TITLE
[FE-12455] Fix typo that caused missing scatter image

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -79079,7 +79079,7 @@ function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
         _chart._setOverlay({
           data: data.image,
           bounds: _renderBoundsMap[data.nonce],
-          nonse: data.nonce,
+          nonce: data.nonce,
           browser: browser,
           redraw: Boolean(redraw)
         });
@@ -79088,7 +79088,7 @@ function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
         _chart._setOverlay({
           data: null,
           bounds: null,
-          nonse: null,
+          nonce: null,
           browser: browser,
           redraw: Boolean(redraw)
         });

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -519,7 +519,7 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
         _chart._setOverlay({
           data: data.image,
           bounds: _renderBoundsMap[data.nonce],
-          nonse: data.nonce,
+          nonce: data.nonce,
           browser,
           redraw: Boolean(redraw)
         })
@@ -528,7 +528,7 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
         _chart._setOverlay({
           data: null,
           bounds: null,
-          nonse: null,
+          nonce: null,
           browser,
           redraw: Boolean(redraw)
         })


### PR DESCRIPTION
# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #https://omnisci.atlassian.net/browse/FE-12455

## Relates with: https://github.com/omnisci/mapd-immerse/pull/7216
## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
