### PR TITLE
jimt/FE-12787 - passes layerName to getFilter

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -55958,7 +55958,7 @@ function rasterLayerPolyMixin(_layer) {
 
     var bboxFilter = "ST_XMax(" + columnExpr + ") >= " + mapBounds._sw.lng + " AND ST_XMin(" + columnExpr + ") <= " + mapBounds._ne.lng + " AND ST_YMax(" + columnExpr + ") >= " + mapBounds._sw.lat + " AND ST_YMin(" + columnExpr + ") <= " + mapBounds._ne.lat;
 
-    var allFilters = _layer.crossfilter().getFilter();
+    var allFilters = _layer.crossfilter().getFilter(layerName);
     var otherChartFilters = allFilters.filter(function (f, i) {
       return i !== _layer.dimension().getDimensionIndex() && f !== "" && f != null;
     });

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -579,7 +579,7 @@ export default function rasterLayerPolyMixin(_layer) {
 
     const bboxFilter = `ST_XMax(${columnExpr}) >= ${mapBounds._sw.lng} AND ST_XMin(${columnExpr}) <= ${mapBounds._ne.lng} AND ST_YMax(${columnExpr}) >= ${mapBounds._sw.lat} AND ST_YMin(${columnExpr}) <= ${mapBounds._ne.lat}`
 
-    const allFilters = _layer.crossfilter().getFilter()
+    const allFilters = _layer.crossfilter().getFilter(layerName)
     const otherChartFilters = allFilters.filter(
       (f, i) =>
         i !== _layer.dimension().getDimensionIndex() && f !== "" && f != null


### PR DESCRIPTION
Nearly trivial fix. Just hand in the layerName to the getFilter call.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
