### PR TITLE
[FE-12805] Reflect opacity to null value - filtered poly

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -55865,7 +55865,6 @@ function rasterLayerPolyMixin(_layer) {
       var colorRange = state.encoding.color.range.map(function (c) {
         return (0, _utilsVega.adjustOpacity)(c, state.encoding.color.opacity);
       });
-      debugger;
       var _colorScaleName = getColorScaleName(layerName);
       if (state.encoding.color.type === "quantitative") {
         scales.push({

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -55434,7 +55434,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) { arr2[i] = arr[i]; } return arr2; } else { return Array.from(arr); } }
 
 var polyDefaultScaleColor = "rgba(214, 215, 214, 0.65)";
-var polyNullScaleColor = "rgba(214, 215, 214, 0.65)";
+var polyNullScaleColor = "#d6d7d6";
 
 var vegaLineJoinOptions = ["miter", "round", "bevel"];
 var polyTableGeomColumns = {
@@ -55854,7 +55854,7 @@ function rasterLayerPolyMixin(_layer) {
         type: "ordinal",
         domain: [1],
         range: [(0, _utilsVega.adjustOpacity)(state.encoding.color.value, state.encoding.color.opacity)],
-        nullValue: polyNullScaleColor,
+        nullValue: (0, _utilsVega.adjustOpacity)(polyNullScaleColor, state.encoding.color.opacity),
         default: polyDefaultScaleColor
       });
       fillColor = {
@@ -55865,6 +55865,7 @@ function rasterLayerPolyMixin(_layer) {
       var colorRange = state.encoding.color.range.map(function (c) {
         return (0, _utilsVega.adjustOpacity)(c, state.encoding.color.opacity);
       });
+      debugger;
       var _colorScaleName = getColorScaleName(layerName);
       if (state.encoding.color.type === "quantitative") {
         scales.push({
@@ -55872,7 +55873,7 @@ function rasterLayerPolyMixin(_layer) {
           type: "quantize",
           domain: autocolors ? { data: getStatsLayerName(), fields: ["mincolor", "maxcolor"] } : state.encoding.color.domain,
           range: colorRange,
-          nullValue: polyNullScaleColor,
+          nullValue: (0, _utilsVega.adjustOpacity)(polyNullScaleColor, state.encoding.color.opacity),
           default: polyDefaultScaleColor
         });
       } else {
@@ -55881,8 +55882,8 @@ function rasterLayerPolyMixin(_layer) {
           type: "ordinal",
           domain: state.encoding.color.domain,
           range: colorRange,
-          nullValue: colorRange[colorRange.length - 1] || polyNullScaleColor, // Other category is concatenated to the main range, so it should be always at the end
-          default: colorRange[colorRange.length - 1] || state.encoding.color.default
+          nullValue: (0, _utilsVega.adjustOpacity)(polyNullScaleColor, state.encoding.color.opacity),
+          default: colorRange[colorRange.length - 1] || state.encoding.color.default // Other category is concatenated to the main range, so it should be always at the end
         });
       }
 

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -55854,7 +55854,7 @@ function rasterLayerPolyMixin(_layer) {
         type: "ordinal",
         domain: [1],
         range: [(0, _utilsVega.adjustOpacity)(state.encoding.color.value, state.encoding.color.opacity)],
-        nullValue: (0, _utilsVega.adjustOpacity)(polyNullScaleColor, state.encoding.color.opacity),
+        nullValue: (0, _utilsVega.adjustOpacity)(polyNullScaleColor, state.encoding.color.opacity || 0.65),
         default: polyDefaultScaleColor
       });
       fillColor = {
@@ -55872,7 +55872,7 @@ function rasterLayerPolyMixin(_layer) {
           type: "quantize",
           domain: autocolors ? { data: getStatsLayerName(), fields: ["mincolor", "maxcolor"] } : state.encoding.color.domain,
           range: colorRange,
-          nullValue: (0, _utilsVega.adjustOpacity)(polyNullScaleColor, state.encoding.color.opacity),
+          nullValue: (0, _utilsVega.adjustOpacity)(polyNullScaleColor, state.encoding.color.opacity || 0.65),
           default: polyDefaultScaleColor
         });
       } else {
@@ -55881,7 +55881,7 @@ function rasterLayerPolyMixin(_layer) {
           type: "ordinal",
           domain: state.encoding.color.domain,
           range: colorRange,
-          nullValue: (0, _utilsVega.adjustOpacity)(polyNullScaleColor, state.encoding.color.opacity),
+          nullValue: (0, _utilsVega.adjustOpacity)(polyNullScaleColor, state.encoding.color.opacity || 0.65),
           default: colorRange[colorRange.length - 1] || state.encoding.color.default // Other category is concatenated to the main range, so it should be always at the end
         });
       }

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -478,7 +478,6 @@ export default function rasterLayerPolyMixin(_layer) {
       const colorRange = state.encoding.color.range.map(c =>
         adjustOpacity(c, state.encoding.color.opacity)
       )
-      debugger
       const colorScaleName = getColorScaleName(layerName)
       if (state.encoding.color.type === "quantitative") {
         scales.push({

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -12,7 +12,7 @@ import { lastFilteredSize, setLastFilteredSize } from "../core/core-async"
 import parseFactsFromCustomSQL from "../utils/custom-sql-parser"
 
 const polyDefaultScaleColor = "rgba(214, 215, 214, 0.65)"
-const polyNullScaleColor = "rgba(214, 215, 214, 0.65)"
+const polyNullScaleColor = "#d6d7d6"
 
 const vegaLineJoinOptions = ["miter", "round", "bevel"]
 const polyTableGeomColumns = {
@@ -464,7 +464,10 @@ export default function rasterLayerPolyMixin(_layer) {
             state.encoding.color.opacity
           )
         ],
-        nullValue: polyNullScaleColor,
+        nullValue: adjustOpacity(
+          polyNullScaleColor,
+          state.encoding.color.opacity
+        ),
         default: polyDefaultScaleColor
       })
       fillColor = {
@@ -475,6 +478,7 @@ export default function rasterLayerPolyMixin(_layer) {
       const colorRange = state.encoding.color.range.map(c =>
         adjustOpacity(c, state.encoding.color.opacity)
       )
+      debugger
       const colorScaleName = getColorScaleName(layerName)
       if (state.encoding.color.type === "quantitative") {
         scales.push({
@@ -484,7 +488,10 @@ export default function rasterLayerPolyMixin(_layer) {
             ? { data: getStatsLayerName(), fields: ["mincolor", "maxcolor"] }
             : state.encoding.color.domain,
           range: colorRange,
-          nullValue: polyNullScaleColor,
+          nullValue: adjustOpacity(
+            polyNullScaleColor,
+            state.encoding.color.opacity
+          ),
           default: polyDefaultScaleColor
         })
       } else {
@@ -493,9 +500,12 @@ export default function rasterLayerPolyMixin(_layer) {
           type: "ordinal",
           domain: state.encoding.color.domain,
           range: colorRange,
-          nullValue: colorRange[colorRange.length - 1] || polyNullScaleColor, // Other category is concatenated to the main range, so it should be always at the end
+          nullValue: adjustOpacity(
+            polyNullScaleColor,
+            state.encoding.color.opacity
+          ),
           default:
-            colorRange[colorRange.length - 1] || state.encoding.color.default
+            colorRange[colorRange.length - 1] || state.encoding.color.default // Other category is concatenated to the main range, so it should be always at the end
         })
       }
 

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -466,7 +466,7 @@ export default function rasterLayerPolyMixin(_layer) {
         ],
         nullValue: adjustOpacity(
           polyNullScaleColor,
-          state.encoding.color.opacity
+          state.encoding.color.opacity || 0.65
         ),
         default: polyDefaultScaleColor
       })
@@ -489,7 +489,7 @@ export default function rasterLayerPolyMixin(_layer) {
           range: colorRange,
           nullValue: adjustOpacity(
             polyNullScaleColor,
-            state.encoding.color.opacity
+            state.encoding.color.opacity || 0.65
           ),
           default: polyDefaultScaleColor
         })
@@ -501,7 +501,7 @@ export default function rasterLayerPolyMixin(_layer) {
           range: colorRange,
           nullValue: adjustOpacity(
             polyNullScaleColor,
-            state.encoding.color.opacity
+            state.encoding.color.opacity || 0.65
           ),
           default:
             colorRange[colorRange.length - 1] || state.encoding.color.default // Other category is concatenated to the main range, so it should be always at the end

--- a/src/mixins/raster-layer-poly-mixin.unit.spec.js
+++ b/src/mixins/raster-layer-poly-mixin.unit.spec.js
@@ -103,7 +103,7 @@ describe("rasterLayerPolyMixin", () => {
             type: "quantize",
             domain: [0, 100],
             range: ["black", "blue"],
-            nullValue: "rgba(214, 215, 214, 0.65)",
+            nullValue: "rgba(214,215,214,0.65)",
             default: "rgba(214, 215, 214, 0.65)"
           }
         ],
@@ -207,7 +207,7 @@ describe("rasterLayerPolyMixin", () => {
             type: "quantize",
             domain: [0, 100],
             range: ["black", "blue"],
-            nullValue: "rgba(214, 215, 214, 0.65)",
+            nullValue: "rgba(214,215,214,0.65)",
             default: "rgba(214, 215, 214, 0.65)"
           }
         ],
@@ -310,7 +310,7 @@ describe("rasterLayerPolyMixin", () => {
             type: "quantize",
             domain: [0, 100],
             range: ["black", "blue"],
-            nullValue: "rgba(214, 215, 214, 0.65)",
+            nullValue: "rgba(214,215,214,0.65)",
             default: "rgba(214, 215, 214, 0.65)"
           }
         ],
@@ -432,7 +432,7 @@ describe("rasterLayerPolyMixin", () => {
             type: "quantize",
             domain: { data: "polys_stats", fields: ["mincolor", "maxcolor"] },
             range: ["black", "blue"],
-            nullValue: "rgba(214, 215, 214, 0.65)",
+            nullValue: "rgba(214,215,214,0.65)",
             default: "rgba(214, 215, 214, 0.65)"
           }
         ],


### PR DESCRIPTION
# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #https://omnisci.atlassian.net/browse/FE-12805

## Relates with: https://github.com/omnisci/mapd-immerse/pull/7359
## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
