### PR TITLE
[FE-12813] Fix same basemap lost image by using styledata listener

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -35018,24 +35018,26 @@ function mapMixin(_chart, chartDivId, _mapboxgl) {
           init(bounds).then(function () {
             resolve(_chart);
           });
+        }
+      });
 
-          // reapplying the previous style's render layer to the new style layer when basemap gets changed
-          if (savedLayers.length) {
-            Object.entries(savedSources).forEach(function (_ref4) {
-              var _ref5 = _slicedToArray(_ref4, 2),
-                  id = _ref5[0],
-                  source = _ref5[1];
+      _map.on("styledata", function () {
+        // reapplying the previous style's render layer to the new style layer when basemap gets changed
+        if (savedLayers.length) {
+          Object.entries(savedSources).forEach(function (_ref4) {
+            var _ref5 = _slicedToArray(_ref4, 2),
+                id = _ref5[0],
+                source = _ref5[1];
 
-              if (!_map.getSource(source)) {
-                _map.addSource(id, source);
-                savedLayers.forEach(function (layer) {
-                  _map.addLayer(layer);
-                });
-                savedLayers = [];
-                savedSources = {};
-              }
-            });
-          }
+            if (!_map.getSource(source)) {
+              _map.addSource(id, source);
+              savedLayers.forEach(function (layer) {
+                _map.addLayer(layer);
+              });
+              savedLayers = [];
+              savedSources = {};
+            }
+          });
         }
       });
 

--- a/src/mixins/map-mixin.js
+++ b/src/mixins/map-mixin.js
@@ -831,20 +831,22 @@ export default function mapMixin(
           init(bounds).then(() => {
             resolve(_chart)
           })
+        }
+      })
 
-          // reapplying the previous style's render layer to the new style layer when basemap gets changed
-          if (savedLayers.length) {
-            Object.entries(savedSources).forEach(([id, source]) => {
-              if (!_map.getSource(source)) {
-                _map.addSource(id, source)
-                savedLayers.forEach(layer => {
-                  _map.addLayer(layer)
-                })
-                savedLayers = []
-                savedSources = {}
-              }
-            })
-          }
+      _map.on("styledata", () => {
+        // reapplying the previous style's render layer to the new style layer when basemap gets changed
+        if (savedLayers.length) {
+          Object.entries(savedSources).forEach(([id, source]) => {
+            if (!_map.getSource(source)) {
+              _map.addSource(id, source)
+              savedLayers.forEach(layer => {
+                _map.addLayer(layer)
+              })
+              savedLayers = []
+              savedSources = {}
+            }
+          })
         }
       })
 


### PR DESCRIPTION
Description: 
_map.on("style.load" ...) is not called when the same style reselected, so using _map.on("styledata" ... ) to capture the same style event to reapply the rendered image after changing the basemap.
# Merge Checklist

## Relates with: https://github.com/omnisci/mapd-immerse/pull/7364
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #https://omnisci.atlassian.net/browse/FE-12813

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
