### PR TITLE
[FE-12815] :bug: fixed parsing issue: columns starting with keywords

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -56242,71 +56242,9 @@ var Whitespace = (0, _chevrotain.createToken)({
   group: _chevrotain.Lexer.SKIPPED
 });
 
-// XXX:
-// Window functions (OVER, PARTITION BY, USING, NULLS, FIRST, LAST, etc)
-// Type casts (CAST ... AS ...)
-// COLLATE
-// Sub-queries (SELECT, et al)
-// ARRAY
-// ROW
-var Keyword = (0, _chevrotain.createToken)({ name: "Keyword", pattern: _chevrotain.Lexer.NA });
-var All = (0, _chevrotain.createToken)({ name: "All", pattern: /all/i, categories: [Keyword] });
-var Distinct = (0, _chevrotain.createToken)({
-  name: "Distinct",
-  pattern: /distinct/i,
-  categories: [Keyword]
-});
-var OrderBy = (0, _chevrotain.createToken)({
-  name: "OrderBy",
-  pattern: /order by/i,
-  categories: [Keyword]
-});
-var Asc = (0, _chevrotain.createToken)({
-  name: "Ascending",
-  pattern: /asc/i,
-  categories: [Keyword]
-});
-var Desc = (0, _chevrotain.createToken)({
-  name: "Descending",
-  pattern: /desc/i,
-  categories: [Keyword]
-});
-var Cast = (0, _chevrotain.createToken)({
-  name: "Cast",
-  pattern: /cast/i,
-  categories: [Keyword]
-});
-var As = (0, _chevrotain.createToken)({
-  name: "As",
-  pattern: /as/i,
-  categories: [Keyword]
-});
-var Case = (0, _chevrotain.createToken)({
-  name: "Case",
-  pattern: /case/i,
-  categories: [Keyword]
-});
-var When = (0, _chevrotain.createToken)({
-  name: "When",
-  pattern: /when/i,
-  categories: [Keyword]
-});
-var Then = (0, _chevrotain.createToken)({
-  name: "Then",
-  pattern: /then/i,
-  categories: [Keyword]
-});
-var Else = (0, _chevrotain.createToken)({
-  name: "Else",
-  pattern: /else/i,
-  categories: [Keyword]
-});
-var End = (0, _chevrotain.createToken)({
-  name: "End",
-  pattern: /end/i,
-  categories: [Keyword]
-});
-
+// We need to define the Identifier here, to use as a "longer_alt" for all
+// keywords. But it'll appear after keywords in the tokenizer.
+//
 // XXX:
 // support for non-latin characters?
 // U&"..." identifiers?
@@ -56321,6 +56259,86 @@ var QuotedIdentifier = (0, _chevrotain.createToken)({
   name: "QuotedIdentifier",
   pattern: /"(?:[^"]|"")+"/,
   categories: [Identifier]
+});
+
+// XXX:
+// Window functions (OVER, PARTITION BY, USING, NULLS, FIRST, LAST, etc)
+// Type casts (CAST ... AS ...)
+// COLLATE
+// Sub-queries (SELECT, et al)
+// ARRAY
+// ROW
+var Keyword = (0, _chevrotain.createToken)({ name: "Keyword", pattern: _chevrotain.Lexer.NA });
+var All = (0, _chevrotain.createToken)({
+  name: "All",
+  pattern: /all/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+});
+var Distinct = (0, _chevrotain.createToken)({
+  name: "Distinct",
+  pattern: /distinct/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+});
+var OrderBy = (0, _chevrotain.createToken)({
+  name: "OrderBy",
+  pattern: /order by/i,
+  categories: [Keyword]
+});
+var Asc = (0, _chevrotain.createToken)({
+  name: "Ascending",
+  pattern: /asc/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+});
+var Desc = (0, _chevrotain.createToken)({
+  name: "Descending",
+  pattern: /desc/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+});
+var Cast = (0, _chevrotain.createToken)({
+  name: "Cast",
+  pattern: /cast/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+});
+var As = (0, _chevrotain.createToken)({
+  name: "As",
+  pattern: /as/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+});
+var Case = (0, _chevrotain.createToken)({
+  name: "Case",
+  pattern: /case/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+});
+var When = (0, _chevrotain.createToken)({
+  name: "When",
+  pattern: /when/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+});
+var Then = (0, _chevrotain.createToken)({
+  name: "Then",
+  pattern: /then/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+});
+var Else = (0, _chevrotain.createToken)({
+  name: "Else",
+  pattern: /else/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+});
+var End = (0, _chevrotain.createToken)({
+  name: "End",
+  pattern: /end/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
 });
 
 // XXX:
@@ -56420,17 +56438,20 @@ var MembershipOperator = (0, _chevrotain.createToken)({
 var BetweenOperator = (0, _chevrotain.createToken)({
   name: "BetweenOperator",
   pattern: /between/i,
-  categories: [MembershipOperator]
+  categories: [MembershipOperator],
+  longer_alt: UnquotedIdentifier
 });
 var InOperator = (0, _chevrotain.createToken)({
   name: "InOperator",
   pattern: /in/i,
-  categories: [MembershipOperator]
+  categories: [MembershipOperator],
+  longer_alt: UnquotedIdentifier
 });
 var LikeOperator = (0, _chevrotain.createToken)({
   name: "LikeOperator",
   pattern: /i?like/i,
-  categories: [MembershipOperator]
+  categories: [MembershipOperator],
+  longer_alt: UnquotedIdentifier
 });
 
 var ComparisonOperator = (0, _chevrotain.createToken)({
@@ -56472,7 +56493,8 @@ var GreaterThanEqualOperator = (0, _chevrotain.createToken)({
 var IsOperator = (0, _chevrotain.createToken)({
   name: "IsOperator",
   pattern: /is/i,
-  categories: [BinaryOperator]
+  categories: [BinaryOperator],
+  longer_alt: UnquotedIdentifier
 });
 var IsPredicate = (0, _chevrotain.createToken)({
   name: "IsPredicate",
@@ -56482,32 +56504,38 @@ var IsPredicate = (0, _chevrotain.createToken)({
 var Not = (0, _chevrotain.createToken)({
   name: "Not",
   pattern: /not/i,
-  categories: [PrefixOperator, Keyword]
+  categories: [PrefixOperator, Keyword],
+  longer_alt: UnquotedIdentifier
 });
 var Null = (0, _chevrotain.createToken)({
   name: "Null",
   pattern: /null/i,
-  categories: [IsPredicate, Keyword]
+  categories: [IsPredicate, Keyword],
+  longer_alt: UnquotedIdentifier
 });
 var True = (0, _chevrotain.createToken)({
   name: "True",
   pattern: /true/i,
-  categories: [IsPredicate, Keyword]
+  categories: [IsPredicate, Keyword],
+  longer_alt: UnquotedIdentifier
 });
 var False = (0, _chevrotain.createToken)({
   name: "False",
   pattern: /false/i,
-  categories: [IsPredicate, Keyword]
+  categories: [IsPredicate, Keyword],
+  longer_alt: UnquotedIdentifier
 });
 var And = (0, _chevrotain.createToken)({
   name: "And",
   pattern: /and/i,
-  categories: [BinaryOperator, Keyword]
+  categories: [BinaryOperator, Keyword],
+  longer_alt: UnquotedIdentifier
 });
 var Or = (0, _chevrotain.createToken)({
   name: "Or",
   pattern: /or/i,
-  categories: [BinaryOperator, Keyword]
+  categories: [BinaryOperator, Keyword],
+  longer_alt: UnquotedIdentifier
 });
 
 // XXX:

--- a/src/utils/custom-sql-parser.js
+++ b/src/utils/custom-sql-parser.js
@@ -11,71 +11,9 @@ const Whitespace = createToken({
   group: Lexer.SKIPPED
 })
 
-// XXX:
-// Window functions (OVER, PARTITION BY, USING, NULLS, FIRST, LAST, etc)
-// Type casts (CAST ... AS ...)
-// COLLATE
-// Sub-queries (SELECT, et al)
-// ARRAY
-// ROW
-const Keyword = createToken({ name: "Keyword", pattern: Lexer.NA })
-const All = createToken({ name: "All", pattern: /all/i, categories: [Keyword] })
-const Distinct = createToken({
-  name: "Distinct",
-  pattern: /distinct/i,
-  categories: [Keyword]
-})
-const OrderBy = createToken({
-  name: "OrderBy",
-  pattern: /order by/i,
-  categories: [Keyword]
-})
-const Asc = createToken({
-  name: "Ascending",
-  pattern: /asc/i,
-  categories: [Keyword]
-})
-const Desc = createToken({
-  name: "Descending",
-  pattern: /desc/i,
-  categories: [Keyword]
-})
-const Cast = createToken({
-  name: "Cast",
-  pattern: /cast/i,
-  categories: [Keyword]
-})
-const As = createToken({
-  name: "As",
-  pattern: /as/i,
-  categories: [Keyword]
-})
-const Case = createToken({
-  name: "Case",
-  pattern: /case/i,
-  categories: [Keyword]
-})
-const When = createToken({
-  name: "When",
-  pattern: /when/i,
-  categories: [Keyword]
-})
-const Then = createToken({
-  name: "Then",
-  pattern: /then/i,
-  categories: [Keyword]
-})
-const Else = createToken({
-  name: "Else",
-  pattern: /else/i,
-  categories: [Keyword]
-})
-const End = createToken({
-  name: "End",
-  pattern: /end/i,
-  categories: [Keyword]
-})
-
+// We need to define the Identifier here, to use as a "longer_alt" for all
+// keywords. But it'll appear after keywords in the tokenizer.
+//
 // XXX:
 // support for non-latin characters?
 // U&"..." identifiers?
@@ -90,6 +28,86 @@ const QuotedIdentifier = createToken({
   name: "QuotedIdentifier",
   pattern: /"(?:[^"]|"")+"/,
   categories: [Identifier]
+})
+
+// XXX:
+// Window functions (OVER, PARTITION BY, USING, NULLS, FIRST, LAST, etc)
+// Type casts (CAST ... AS ...)
+// COLLATE
+// Sub-queries (SELECT, et al)
+// ARRAY
+// ROW
+const Keyword = createToken({ name: "Keyword", pattern: Lexer.NA })
+const All = createToken({
+  name: "All",
+  pattern: /all/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+})
+const Distinct = createToken({
+  name: "Distinct",
+  pattern: /distinct/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+})
+const OrderBy = createToken({
+  name: "OrderBy",
+  pattern: /order by/i,
+  categories: [Keyword]
+})
+const Asc = createToken({
+  name: "Ascending",
+  pattern: /asc/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+})
+const Desc = createToken({
+  name: "Descending",
+  pattern: /desc/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+})
+const Cast = createToken({
+  name: "Cast",
+  pattern: /cast/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+})
+const As = createToken({
+  name: "As",
+  pattern: /as/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+})
+const Case = createToken({
+  name: "Case",
+  pattern: /case/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+})
+const When = createToken({
+  name: "When",
+  pattern: /when/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+})
+const Then = createToken({
+  name: "Then",
+  pattern: /then/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+})
+const Else = createToken({
+  name: "Else",
+  pattern: /else/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
+})
+const End = createToken({
+  name: "End",
+  pattern: /end/i,
+  categories: [Keyword],
+  longer_alt: UnquotedIdentifier
 })
 
 // XXX:
@@ -189,17 +207,20 @@ const MembershipOperator = createToken({
 const BetweenOperator = createToken({
   name: "BetweenOperator",
   pattern: /between/i,
-  categories: [MembershipOperator]
+  categories: [MembershipOperator],
+  longer_alt: UnquotedIdentifier
 })
 const InOperator = createToken({
   name: "InOperator",
   pattern: /in/i,
-  categories: [MembershipOperator]
+  categories: [MembershipOperator],
+  longer_alt: UnquotedIdentifier
 })
 const LikeOperator = createToken({
   name: "LikeOperator",
   pattern: /i?like/i,
-  categories: [MembershipOperator]
+  categories: [MembershipOperator],
+  longer_alt: UnquotedIdentifier
 })
 
 const ComparisonOperator = createToken({
@@ -241,7 +262,8 @@ const GreaterThanEqualOperator = createToken({
 const IsOperator = createToken({
   name: "IsOperator",
   pattern: /is/i,
-  categories: [BinaryOperator]
+  categories: [BinaryOperator],
+  longer_alt: UnquotedIdentifier
 })
 const IsPredicate = createToken({
   name: "IsPredicate",
@@ -251,32 +273,38 @@ const IsPredicate = createToken({
 const Not = createToken({
   name: "Not",
   pattern: /not/i,
-  categories: [PrefixOperator, Keyword]
+  categories: [PrefixOperator, Keyword],
+  longer_alt: UnquotedIdentifier
 })
 const Null = createToken({
   name: "Null",
   pattern: /null/i,
-  categories: [IsPredicate, Keyword]
+  categories: [IsPredicate, Keyword],
+  longer_alt: UnquotedIdentifier
 })
 const True = createToken({
   name: "True",
   pattern: /true/i,
-  categories: [IsPredicate, Keyword]
+  categories: [IsPredicate, Keyword],
+  longer_alt: UnquotedIdentifier
 })
 const False = createToken({
   name: "False",
   pattern: /false/i,
-  categories: [IsPredicate, Keyword]
+  categories: [IsPredicate, Keyword],
+  longer_alt: UnquotedIdentifier
 })
 const And = createToken({
   name: "And",
   pattern: /and/i,
-  categories: [BinaryOperator, Keyword]
+  categories: [BinaryOperator, Keyword],
+  longer_alt: UnquotedIdentifier
 })
 const Or = createToken({
   name: "Or",
   pattern: /or/i,
-  categories: [BinaryOperator, Keyword]
+  categories: [BinaryOperator, Keyword],
+  longer_alt: UnquotedIdentifier
 })
 
 // XXX:

--- a/src/utils/custom-sql-parser.unit.spec.js
+++ b/src/utils/custom-sql-parser.unit.spec.js
@@ -189,7 +189,9 @@ describe("parseFactsFromCustomSQL", () => {
 
     it("should project the first condition", () => {
       expect(factProjections).to.have.lengthOf(1)
-      expect(factProjections[0]).to.equal("sum(case when flight_year > 20.0 then origin_lat end)")
+      expect(factProjections[0]).to.equal(
+        "sum(case when flight_year > 20.0 then origin_lat end)"
+      )
     })
 
     it("should have one alias", () => {
@@ -198,9 +200,7 @@ describe("parseFactsFromCustomSQL", () => {
     })
 
     it("should have replaced the fact projections", () => {
-      expect(expression).to.equal(
-        "color.color0"
-      )
+      expect(expression).to.equal("color.color0")
     })
   })
 })

--- a/src/utils/custom-sql-parser.unit.spec.js
+++ b/src/utils/custom-sql-parser.unit.spec.js
@@ -175,4 +175,32 @@ describe("parseFactsFromCustomSQL", () => {
       )
     })
   })
+
+  describe("sum(case when flight_year > 20.0 then origin_lat end)", () => {
+    const {
+      factProjections,
+      factAliases,
+      expression
+    } = parseFactsFromCustomSQL(
+      "fact",
+      "color",
+      "sum(case when flight_year > 20.0 then origin_lat end)"
+    )
+
+    it("should project the first condition", () => {
+      expect(factProjections).to.have.lengthOf(1)
+      expect(factProjections[0]).to.equal("sum(case when flight_year > 20.0 then origin_lat end)")
+    })
+
+    it("should have one alias", () => {
+      expect(factAliases).to.have.lengthOf(1)
+      expect(factAliases[0]).to.equal("color0")
+    })
+
+    it("should have replaced the fact projections", () => {
+      expect(expression).to.equal(
+        "color.color0"
+      )
+    })
+  })
 })


### PR DESCRIPTION
The sql parser was failing if a column name began with a keyword, such as `origin_lon` beginning with `or`.

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes [FE-12815](https://omnisci.atlassian.net/browse/FE-12815)

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
