### PR TITLE
[FE-12895] Break words in legends so they conform to user-configured width 

### DIFF
--- a/dist/mapdc.css
+++ b/dist/mapdc.css
@@ -1425,7 +1425,8 @@ body {
   .dc-legend .legend-item-text {
     flex-grow: 1;
     padding: 4px;
-    line-height: 1; }
+    line-height: 1;
+    word-break: break-word; }
   .dc-legend .dc-legend-item {
     display: flex;
     align-items: center;

--- a/dist/mapdc.css
+++ b/dist/mapdc.css
@@ -1364,7 +1364,8 @@ body {
     margin: 4px 4px 0 4px;
     position: relative;
     padding-right: 20px;
-    padding-bottom: 2px; }
+    padding-bottom: 2px;
+    word-break: break-word; }
   .dc-legend .toggle-btn {
     width: 24px;
     height: 24px;
@@ -1988,6 +1989,7 @@ body {
 .nominal-legend .legend-row .text {
   flex-grow: 1;
   padding: 4px;
+  word-break: break-word;
   line-height: 1; }
 
 .gradient-legend .range {

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -1696,6 +1696,7 @@ body {
         flex-grow: 1;
         padding: 4px;
         line-height: 1;
+        word-break: break-word;
     }
 
     .dc-legend-item {

--- a/scss/chart.scss
+++ b/scss/chart.scss
@@ -1606,6 +1606,7 @@ body {
         position: relative;
         padding-right: 20px;
         padding-bottom: 2px;
+        word-break: break-word;
     }
 
     .toggle-btn {


### PR DESCRIPTION
[FE-12895](https://omnisci.atlassian.net/browse/FE-12895)

Related: https://github.com/omnisci/mapd-immerse/pull/7401

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
