### PR TITLE
[FE-12302][FE-11372] raise an event after gen vega spec

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -78791,6 +78791,10 @@ var _extends = Object.assign || function (target) { for (var i = 1; i < argument
 
 exports.default = rasterChart;
 
+var _d = __webpack_require__(1);
+
+var _d2 = _interopRequireDefault(_d);
+
 var _stackedLegend = __webpack_require__(268);
 
 var _coordinateGridRasterMixin = __webpack_require__(190);
@@ -78859,6 +78863,10 @@ function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
   var _layers = [];
   var _hasBeenRendered = false;
 
+  var _events = ["vegaSpec"];
+  var _listeners = _d2.default.dispatch.apply(_d2.default, _events);
+  var _on = _chart.on.bind(_chart);
+
   var _x = null;
   var _y = null;
   var _xScaleName = "x";
@@ -78878,6 +78886,19 @@ function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
   var _legendOpen = true;
 
   var _shiftToZoom = false;
+
+  _chart.on = function (event, listener) {
+    if (_events.indexOf(event) === -1) {
+      _on(event, listener);
+    } else {
+      _listeners.on(event, listener);
+    }
+    return _chart;
+  };
+
+  _chart._invokeVegaSpecListener = function (spec) {
+    _listeners.vegaSpec(_chart, spec);
+  };
 
   _chart.legendOpen = function (_) {
     if (!arguments.length) {
@@ -79155,11 +79176,11 @@ function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
     var useRenderBounds = renderBounds && renderBounds.length === 4 && renderBounds[0] instanceof Array && renderBounds[0].length === 2;
 
     if (_x === null) {
-      _x = d3.scale.linear();
+      _x = _d2.default.scale.linear();
     }
 
     if (_y === null) {
-      _y = d3.scale.linear();
+      _y = _d2.default.scale.linear();
     }
 
     // if _chart.useLonLat() is not true, the chart bounds have already been projected into mercator space
@@ -79490,6 +79511,8 @@ function genLayeredVega(chart) {
     projections: projections,
     marks: marks
   };
+
+  chart._invokeVegaSpecListener(vegaSpec);
 
   return vegaSpec;
 }

--- a/src/charts/raster-chart.js
+++ b/src/charts/raster-chart.js
@@ -1,3 +1,4 @@
+import d3 from "d3"
 import {
   getLegendStateFromChart,
   handleLegendDoneRender,
@@ -60,6 +61,10 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
   let _layers = []
   let _hasBeenRendered = false
 
+  const _events = ["vegaSpec"]
+  const _listeners = d3.dispatch.apply(d3, _events)
+  const _on = _chart.on.bind(_chart)
+
   let _x = null
   let _y = null
   const _xScaleName = "x"
@@ -79,6 +84,19 @@ export default function rasterChart(parent, useMap, chartGroup, _mapboxgl) {
   let _legendOpen = true
 
   let _shiftToZoom = false
+
+  _chart.on = function(event, listener) {
+    if (_events.indexOf(event) === -1) {
+      _on(event, listener)
+    } else {
+      _listeners.on(event, listener)
+    }
+    return _chart
+  }
+
+  _chart._invokeVegaSpecListener = function(spec) {
+    _listeners.vegaSpec(_chart, spec)
+  }
 
   _chart.legendOpen = function(_) {
     if (!arguments.length) {
@@ -786,6 +804,8 @@ function genLayeredVega(chart) {
     projections,
     marks
   }
+
+  chart._invokeVegaSpecListener(vegaSpec)
 
   return vegaSpec
 }


### PR DESCRIPTION
After the vega spec is generated, an event is raised giving other code a chance to manipulate the spec before sending it off to the server. This is used in Immerse.