### PR TITLE
[FE-13145] :bug: fixed tbl binned filter highlighting

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -61506,6 +61506,9 @@ function legendMixin(chart) {
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
 exports.addFilterHandler = addFilterHandler;
 exports.hasFilterHandler = hasFilterHandler;
 exports.filterHandlerWithChartContext = filterHandlerWithChartContext;
@@ -61569,15 +61572,13 @@ function hasFilterHandler(filters, testValue) {
       if (Array.isArray(testValueWithISODates)) {
         return (0, _lodash.isEqual)(f, testValueWithISODates);
       }
-      return f.every(function (f2) {
-        return f2 === testValueWithISODates;
-      });
+      return f.length === 1 && f[0] === testValueWithISODates;
     } else if (Array.isArray(testValueWithISODates)) {
       return testValueWithISODates.every(function (f2) {
         return f2 === f;
       });
     }
-    return testValueWithISODates <= f && testValueWithISODates >= f;
+    return (typeof f === "undefined" ? "undefined" : _typeof(f)) === (typeof testValueWithISODates === "undefined" ? "undefined" : _typeof(testValueWithISODates)) && testValueWithISODates <= f && testValueWithISODates >= f;
   });
 }
 
@@ -84841,13 +84842,8 @@ function mapdTable(parent, chartGroup) {
         tableRowCls = tableRowCls + "grouped-data ";
 
         if (_chart.hasFilter()) {
-          var keyArray = [];
-          for (var key in d) {
-            if (d.hasOwnProperty(key) && key.includes("key")) {
-              keyArray.push(d[key]);
-            }
-          }
-          tableRowCls = tableRowCls + (!_chart.hasFilter(keyArray) ^ _chart.filtersInverse() ? "deselected" : "selected");
+          var key = _chart.keyAccessor()(d);
+          tableRowCls = tableRowCls + (!_chart.hasFilter(key) ^ _chart.filtersInverse() ? "deselected" : "selected");
         }
       }
       return tableRowCls;

--- a/src/charts/mapd-table.js
+++ b/src/charts/mapd-table.js
@@ -312,15 +312,10 @@ export default function mapdTable(parent, chartGroup) {
         tableRowCls = tableRowCls + "grouped-data "
 
         if (_chart.hasFilter()) {
-          const keyArray = []
-          for (const key in d) {
-            if (d.hasOwnProperty(key) && key.includes("key")) {
-              keyArray.push(d[key])
-            }
-          }
+          const key = _chart.keyAccessor()(d)
           tableRowCls =
             tableRowCls +
-            (!_chart.hasFilter(keyArray) ^ _chart.filtersInverse()
+            (!_chart.hasFilter(key) ^ _chart.filtersInverse()
               ? "deselected"
               : "selected")
         }

--- a/src/mixins/filter-mixin.js
+++ b/src/mixins/filter-mixin.js
@@ -58,11 +58,15 @@ export function hasFilterHandler(filters, testValue) {
       if (Array.isArray(testValueWithISODates)) {
         return isEqual(f, testValueWithISODates)
       }
-      return f.every(f2 => f2 === testValueWithISODates)
+      return f.length === 1 && f[0] === testValueWithISODates
     } else if (Array.isArray(testValueWithISODates)) {
       return testValueWithISODates.every(f2 => f2 === f)
     }
-    return testValueWithISODates <= f && testValueWithISODates >= f
+    return (
+      typeof f === typeof testValueWithISODates &&
+      testValueWithISODates <= f &&
+      testValueWithISODates >= f
+    )
   })
 }
 


### PR DESCRIPTION
When you click a row in table chart, the keyAccessor function runs to generate a key for that row. If there is only one column in the table, the key will be a single value (that value might be an array, in the case of binning - but it's a single value). If there are more than one columns, the key will be an array.

The code that checks if a row has a filter did no such flattening in the case where there was a single column. I switched it to use the same keyAccessor function. I also updated the function that compares the values to check variable types, too, to fix a problem with setting a filter on NULL also highlighting false, and vice versa.