### PR TITLE
call elastic listeners after domain

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -34168,22 +34168,22 @@ function lockAxisMixin(chart) {
   function toggleLock(type) {
     if (type === "y") {
       chart.elasticY(!chart.elasticY());
-      chart._invokeelasticYListener();
       var yDomain = chart.y().domain().slice(0);
       chart._invokeYDomainListener(chart.elasticY() ? chart.originalYMinMax || yDomain : yDomain);
+      chart._invokeelasticYListener();
     } else {
       chart.elasticX(!chart.elasticX());
-      chart._invokeelasticXListener();
       var xDomain = chart.x().domain().slice();
       chart._invokeXDomainListener(chart.elasticX() ? chart.originalXMinMax || xDomain : xDomain);
+      chart._invokeelasticXListener();
       if (chart.focusChart && chart.focusChart()) {
         chart.focusChart().elasticX(!chart.focusChart().elasticX());
-        chart.focusChart()._invokeelasticXListener();
         if (chart.elasticX()) {
           chart.focusChart()._invokeXDomainListener(null);
         } else {
           chart.focusChart()._invokeXDomainListener(chart.x().domain().slice());
         }
+        chart.focusChart()._invokeelasticXListener();
         chart.focusChart().redrawAsync();
       }
     }

--- a/src/mixins/lock-axis-mixin.js
+++ b/src/mixins/lock-axis-mixin.js
@@ -118,7 +118,6 @@ export default function lockAxisMixin(chart) {
   function toggleLock(type) {
     if (type === "y") {
       chart.elasticY(!chart.elasticY())
-      chart._invokeelasticYListener()
       const yDomain = chart
         .y()
         .domain()
@@ -126,9 +125,9 @@ export default function lockAxisMixin(chart) {
       chart._invokeYDomainListener(
         chart.elasticY() ? chart.originalYMinMax || yDomain : yDomain
       )
+      chart._invokeelasticYListener()
     } else {
       chart.elasticX(!chart.elasticX())
-      chart._invokeelasticXListener()
       const xDomain = chart
         .x()
         .domain()
@@ -136,9 +135,9 @@ export default function lockAxisMixin(chart) {
       chart._invokeXDomainListener(
         chart.elasticX() ? chart.originalXMinMax || xDomain : xDomain
       )
+      chart._invokeelasticXListener()
       if (chart.focusChart && chart.focusChart()) {
         chart.focusChart().elasticX(!chart.focusChart().elasticX())
-        chart.focusChart()._invokeelasticXListener()
         if (chart.elasticX()) {
           chart.focusChart()._invokeXDomainListener(null)
         } else {
@@ -149,6 +148,7 @@ export default function lockAxisMixin(chart) {
               .slice()
           )
         }
+        chart.focusChart()._invokeelasticXListener()
         chart.focusChart().redrawAsync()
       }
     }


### PR DESCRIPTION
When locking/unlocking the axis, call the elasticX/Y listeners after calling the domain listeners