### PR TITLE
Adds support for the airplane symbol, legacysymbol vega mark type only initially

### DIFF
--- a/src/mixins/raster-layer-point-mixin.js
+++ b/src/mixins/raster-layer-point-mixin.js
@@ -40,6 +40,7 @@ function validSymbol(type) {
     case "hexagon-horiz":
     case "wedge":
     case "arrow":
+    case "airplane":
       return true
     default:
       return false
@@ -132,15 +133,18 @@ function isValidPostFilter(postFilter) {
   if (value && (aggType || custom)) {
     if (
       (operator === "not between" || operator === "between") &&
-      (typeof min === "number" && !isNaN(min)) &&
-      (typeof max === "number" && !isNaN(max))
+      typeof min === "number" &&
+      !isNaN(min) &&
+      typeof max === "number" &&
+      !isNaN(max)
     ) {
       return true
     } else if (
       (operator === "equals" ||
         operator === "not equals" ||
         operator === "greater than or equals") &&
-      (typeof min === "number" && !isNaN(min))
+      typeof min === "number" &&
+      !isNaN(min)
     ) {
       return true
     } else if (
@@ -573,7 +577,7 @@ export default function rasterLayerPointMixin(_layer) {
 
     const marks = [
       {
-        type: "symbol",
+        type: markType === "airplane" ? "legacysymbol" : "symbol",
         from: {
           data: layerName
         },


### PR DESCRIPTION
Adds support for the initial legacysymbol airplane icon added with this commit: https://github.com/omnisci/omniscidb-internal/commit/743081693d55e04573465e8d0262f961f5d3ae48

# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes #0

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.
