### PR TITLE
[FE-13791][IHS] - fix scatter chart related slowdowns

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -49955,8 +49955,20 @@ function asyncMixin(_chart) {
     });
   };
 
+  var _chartRedrawEnabled = true;
+  var chartRedrawEnabled = function chartRedrawEnabled() {
+    return _chartRedrawEnabled;
+  };
+
+  _chart.enableChartRedraw = function () {
+    _chartRedrawEnabled = true;
+  };
+  _chart.disableChartRedraw = function () {
+    _chartRedrawEnabled = false;
+  };
+
   _chart.redrawAsync = function (queryGroupId, queryCount) {
-    if ((0, _core.refreshDisabled)()) {
+    if ((0, _core.refreshDisabled)() || !chartRedrawEnabled()) {
       return Promise.resolve();
     }
 
@@ -52093,6 +52105,8 @@ var _lockAxisMixin2 = _interopRequireDefault(_lockAxisMixin);
 
 var _errors = __webpack_require__(36);
 
+var _utils = __webpack_require__(4);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 /**
@@ -52827,8 +52841,9 @@ function coordinateGridRasterMixin(_chart, _mapboxgl, browser) {
       }
     };
 
-    if (imgUrl) {
-      // should we check to see if the imgUrl is the same from the previous render?
+    if (imgUrl && imgUrl !== _chart.lastImgUrl || !_utils.utils.deepEquals(renderBounds, _chart.lastRenderBounds)) {
+      _chart.lastImgUrl = imgUrl;
+      _chart.lastRenderBounds = renderBounds;
       _axios2.default.get(imgUrl, {
         responseType: 'arraybuffer'
       }).then(function (_ref) {
@@ -54897,6 +54912,7 @@ function validSymbol(type) {
     case "hexagon-horiz":
     case "wedge":
     case "arrow":
+    case "airplane":
       return true;
     default:
       return false;
@@ -55354,7 +55370,7 @@ function rasterLayerPointMixin(_layer) {
     var scales = (0, _utilsVega.getScales)(state.encoding, layerName, scaledomainfields, getStatsLayerName());
 
     var marks = [{
-      type: "symbol",
+      type: markType === "airplane" ? "legacysymbol" : "symbol",
       from: {
         data: layerName
       },

--- a/src/mixins/async-mixin.js
+++ b/src/mixins/async-mixin.js
@@ -95,8 +95,18 @@ export default function asyncMixin(_chart) {
     })
   }
 
+  let _chartRedrawEnabled = true
+  const chartRedrawEnabled = () => _chartRedrawEnabled
+
+  _chart.enableChartRedraw = function() {
+    _chartRedrawEnabled = true
+  }
+  _chart.disableChartRedraw = function() {
+    _chartRedrawEnabled = false
+  }
+
   _chart.redrawAsync = function(queryGroupId, queryCount) {
-    if (refreshDisabled()) {
+    if (refreshDisabled() || !chartRedrawEnabled()) {
       return Promise.resolve()
     }
 

--- a/src/mixins/coordinate-grid-raster-mixin.js
+++ b/src/mixins/coordinate-grid-raster-mixin.js
@@ -7,6 +7,7 @@ import marginMixin from "./margin-mixin"
 import axios from "axios"
 import lockAxisMixin from "./lock-axis-mixin"
 import { DestroyedChartError } from "../core/errors"
+import { utils } from "../utils/utils"
 
 /**
  * Coordinate Grid Raster is an abstract base chart designed to support coordinate grid based
@@ -749,7 +750,9 @@ export default function coordinateGridRasterMixin (_chart, _mapboxgl, browser) {
       }
     }
 
-    if (imgUrl) { // should we check to see if the imgUrl is the same from the previous render?
+    if (imgUrl && imgUrl !== _chart.lastImgUrl || !utils.deepEquals(renderBounds, _chart.lastRenderBounds)) {
+      _chart.lastImgUrl = imgUrl
+      _chart.lastRenderBounds = renderBounds
       axios.get(imgUrl, {
         responseType: 'arraybuffer'
       }).then(({ data }) => {


### PR DESCRIPTION
Scatter plot has a couple of stupid slowdowns, reported most recently by IHS.

First of all, it will always refresh the retrieved dataURL, even if it's identical to its previous value. The fix here is just to cache the img url + the render bounds, and not bother to do anything if they're both unchanged.

Secondly, during chart creation, it ends up firing off several `redrawAsync` calls before it has even completed its initial render. `setValueFormatter`, `setElasticX`, and `setElasticY` all trigger redraws.

The best way I could see to do this was to add new functionality to `async-mixin` - `enableChartRedraw`/`disableChartRedraw`. So that way we can disable it when we start to create a scatter plot, set the values, then re-enable it when we're done. It's a stupid hack, but so's everything else in mapdc. Note that due to the data involved and race conditions, extra queries are not always fired, but we usually end up with at least 1 extra.

To test, just create some scatter plots and confirm they worked as before, and watch the network tab to confirm that fewer/the same number of network requests fire off.