### PR TITLE
[FE-13887] table param coupling

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -85392,6 +85392,8 @@ function mapdTable(parent, chartGroup) {
     });
   }
 
+  // our default retriever just takes the expr (column), sticks the column on it, then snags
+  // the type from the columns list. Being careful not to blow up if it doesn't exist.
   var _retrieveFilterColType = function _retrieveFilterColType(_ref) {
     var expr = _ref.expr,
         table = _ref.table,
@@ -85401,6 +85403,7 @@ function mapdTable(parent, chartGroup) {
     return columns[key] ? columns[key].type : undefined;
   };
 
+  // but we can also change the type via a custom accessor, if necesary
   _chart.setCustomRetrieveFilterColType = function (func) {
     _retrieveFilterColType = func;
   };
@@ -85412,6 +85415,8 @@ function mapdTable(parent, chartGroup) {
       columns: _crossfilter.getColumns()
     });
 
+    // escape clause - certain values cannot be filtered upon, so if there's no type
+    // we escape. By default, we won't filter on anything that isn't a column in the table.
     if (!type) {
       return;
     }

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -85392,10 +85392,25 @@ function mapdTable(parent, chartGroup) {
     });
   }
 
+  var _retrieveFilterColType = function _retrieveFilterColType(_ref) {
+    var expr = _ref.expr,
+        table = _ref.table,
+        columns = _ref.columns;
+
+    var key = table + "." + expr;
+    return columns[key].type;
+  };
+
+  _chart.setCustomRetrieveFilterColType = function (func) {
+    _retrieveFilterColType = func;
+  };
+
   function filterCol(expr, val) {
-    var key = _crossfilter.getTable()[0] + "." + expr;
-    var columns = _crossfilter.getColumns();
-    var type = columns[key].type;
+    var type = _retrieveFilterColType({
+      expr: expr,
+      table: _crossfilter.getTable()[0],
+      columns: _crossfilter.getColumns()
+    });
 
     if (type === "TIMESTAMP") {
       val = "TIMESTAMP(3) '" + val.toISOString().slice(0, -1) // Slice off the 'Z' at the end

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -85398,7 +85398,7 @@ function mapdTable(parent, chartGroup) {
         columns = _ref.columns;
 
     var key = table + "." + expr;
-    return columns[key].type;
+    return columns[key] ? columns[key].type : undefined;
   };
 
   _chart.setCustomRetrieveFilterColType = function (func) {

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -85412,6 +85412,10 @@ function mapdTable(parent, chartGroup) {
       columns: _crossfilter.getColumns()
     });
 
+    if (!type) {
+      return;
+    }
+
     if (type === "TIMESTAMP") {
       val = "TIMESTAMP(3) '" + val.toISOString().slice(0, -1) // Slice off the 'Z' at the end
       .replace("T", " ") + "'";

--- a/src/charts/mapd-table.js
+++ b/src/charts/mapd-table.js
@@ -524,6 +524,10 @@ export default function mapdTable(parent, chartGroup) {
       columns: _crossfilter.getColumns()
     })
 
+    if (!type) {
+      return
+    }
+
     if (type === "TIMESTAMP") {
       val = `TIMESTAMP(3) '${val
         .toISOString()

--- a/src/charts/mapd-table.js
+++ b/src/charts/mapd-table.js
@@ -508,10 +508,21 @@ export default function mapdTable(parent, chartGroup) {
     })
   }
 
+  let _retrieveFilterColType = ({ expr, table, columns }) => {
+    const key = `${table}.${expr}`
+    return columns[key].type
+  }
+
+  _chart.setCustomRetrieveFilterColType = function(func) {
+    _retrieveFilterColType = func
+  }
+
   function filterCol(expr, val) {
-    const key = _crossfilter.getTable()[0] + "." + expr
-    const columns = _crossfilter.getColumns()
-    const type = columns[key].type
+    const type = _retrieveFilterColType({
+      expr,
+      table: _crossfilter.getTable()[0],
+      columns: _crossfilter.getColumns()
+    })
 
     if (type === "TIMESTAMP") {
       val = `TIMESTAMP(3) '${val

--- a/src/charts/mapd-table.js
+++ b/src/charts/mapd-table.js
@@ -510,7 +510,7 @@ export default function mapdTable(parent, chartGroup) {
 
   let _retrieveFilterColType = ({ expr, table, columns }) => {
     const key = `${table}.${expr}`
-    return columns[key].type
+    return columns[key] ? columns[key].type : undefined
   }
 
   _chart.setCustomRetrieveFilterColType = function(func) {

--- a/src/charts/mapd-table.js
+++ b/src/charts/mapd-table.js
@@ -508,11 +508,14 @@ export default function mapdTable(parent, chartGroup) {
     })
   }
 
+  // our default retriever just takes the expr (column), sticks the column on it, then snags
+  // the type from the columns list. Being careful not to blow up if it doesn't exist.
   let _retrieveFilterColType = ({ expr, table, columns }) => {
     const key = `${table}.${expr}`
     return columns[key] ? columns[key].type : undefined
   }
 
+  // but we can also change the type via a custom accessor, if necesary
   _chart.setCustomRetrieveFilterColType = function(func) {
     _retrieveFilterColType = func
   }
@@ -524,6 +527,8 @@ export default function mapdTable(parent, chartGroup) {
       columns: _crossfilter.getColumns()
     })
 
+    // escape clause - certain values cannot be filtered upon, so if there's no type
+    // we escape. By default, we won't filter on anything that isn't a column in the table.
     if (!type) {
       return
     }


### PR DESCRIPTION
I set up [https://omnisci.atlassian.net/browse/FE-13887](FE-13887) as a centralized ticket for these param/table issues. There are probably more related tickets.

This adds in a hook to mapd-table to allow us to process columns with parameters when they're pulled out for filtering purposes, as opposed to pre-processing them and storing that string on the dimension. Immerse sets the `setCustomRetrieveFilterType` function.

That, in turn, allows us to track usage only when data is fetched.

Also - mapd-table blew up when you attempted to filter on any measure columns that weren't in the table. So it's not just that `${foo}` would break, things like `avg(foo)` or `8` would also break. So this tweaks it to refuse to set a filter entirely if it's not in the table.

There may be cases where you could have set a valid filter with a column of that type, and those would need to be addressed. If such a case exists, then previous to this change it would've crashed immerse. After this change, it will merely prevent creation of that filter (which would've crashed immerse). If such a case can be proven, we should amend the callback in Immerse to allow passage of a type value to allow a filter to be created.