### PR TITLE
[FE-13941][others?] params and poly stuff

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -55818,6 +55818,7 @@ function rasterLayerPolyMixin(_layer) {
         colorField = _parseFactsFromCustom.expression;
       }
 
+      ;
       var _customColorProjectio = _customColorProjectionPostProcessor(color.aggregate, {
         colorProjection: colorProjection,
         colorProjectionAs: colorProjectionAs,

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -55785,6 +55785,8 @@ function rasterLayerPolyMixin(_layer) {
         state = _ref.state,
         lastFilteredSize = _ref.lastFilteredSize,
         isDataExport = _ref.isDataExport;
+
+    /* eslint complexity: ["error", 50] */ // this function is too complex. Sorry.
     var _state$encoding = state.encoding,
         color = _state$encoding.color,
         geocol = _state$encoding.geocol,

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -55818,6 +55818,7 @@ function rasterLayerPolyMixin(_layer) {
         colorField = _parseFactsFromCustom.expression;
       }
 
+      // eslint-disable-next-line no-extra-semi
       ;
       var _customColorProjectio = _customColorProjectionPostProcessor(color.aggregate, {
         colorProjection: colorProjection,

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -55720,6 +55720,14 @@ function rasterLayerPolyMixin(_layer) {
 
   var _scaledPopups = {};
 
+  var _customFetchColorAggregate = function _customFetchColorAggregate(aggregate) {
+    return aggregates;
+  };
+
+  _layer.setCustomFetchColorAggregate = function (func) {
+    _customFetchColorAggregate = func;
+  };
+
   _layer.setState = function (setter) {
     if (typeof setter === "function") {
       state = setter(state);
@@ -55795,7 +55803,7 @@ function rasterLayerPolyMixin(_layer) {
         // parent SELECT.
         // eslint-disable-next-line no-extra-semi
         ;
-        var _parseFactsFromCustom = (0, _customSqlParser2.default)(state.data[0].table, withAlias, color.aggregate);
+        var _parseFactsFromCustom = (0, _customSqlParser2.default)(state.data[0].table, withAlias, _customFetchColorAggregate(color.aggregate));
 
         colorProjection = _parseFactsFromCustom.factProjections;
         colorProjectionAs = _parseFactsFromCustom.factAliases;

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -186,6 +186,7 @@ export default function rasterLayerPolyMixin(_layer) {
         ))
       }
 
+      // eslint-disable-next-line no-extra-semi
       ;({
         colorProjection,
         colorProjectionAs,

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -146,6 +146,7 @@ export default function rasterLayerPolyMixin(_layer) {
     lastFilteredSize,
     isDataExport
   }) {
+    /* eslint complexity: ["error", 50] */ // this function is too complex. Sorry.
     const {
       encoding: { color, geocol, geoTable }
     } = state

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -78,10 +78,17 @@ export default function rasterLayerPolyMixin(_layer) {
 
   const _scaledPopups = {}
 
-  let _customFetchColorAggregate = aggregate => aggregates
+  let _customFetchColorAggregate = aggregate => aggregate
 
   _layer.setCustomFetchColorAggregate = function(func) {
     _customFetchColorAggregate = func
+  }
+
+  let _customColorProjectionPostProcessor = (aggregate, projections) =>
+    projections
+
+  _layer.setCustomColorProjectionPostProcessor = function(func) {
+    _customColorProjectionPostProcessor = func
   }
 
   _layer.setState = function(setter) {
@@ -178,6 +185,16 @@ export default function rasterLayerPolyMixin(_layer) {
           _customFetchColorAggregate(color.aggregate)
         ))
       }
+
+      ({
+        colorProjection,
+        colorProjectionAs,
+        colorField
+      } = _customColorProjectionPostProcessor(color.aggregate, {
+        colorProjection,
+        colorProjectionAs,
+        colorField
+      }))
 
       const withClauseTransforms = []
 

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -186,7 +186,7 @@ export default function rasterLayerPolyMixin(_layer) {
         ))
       }
 
-      ({
+      ;({
         colorProjection,
         colorProjectionAs,
         colorField

--- a/src/mixins/raster-layer-poly-mixin.js
+++ b/src/mixins/raster-layer-poly-mixin.js
@@ -78,6 +78,12 @@ export default function rasterLayerPolyMixin(_layer) {
 
   const _scaledPopups = {}
 
+  let _customFetchColorAggregate = aggregate => aggregates
+
+  _layer.setCustomFetchColorAggregate = function(func) {
+    _customFetchColorAggregate = func
+  }
+
   _layer.setState = function(setter) {
     if (typeof setter === "function") {
       state = setter(state)
@@ -169,7 +175,7 @@ export default function rasterLayerPolyMixin(_layer) {
         } = parseFactsFromCustomSQL(
           state.data[0].table,
           withAlias,
-          color.aggregate
+          _customFetchColorAggregate(color.aggregate)
         ))
       }
 

--- a/src/utils/custom-sql-parser.js
+++ b/src/utils/custom-sql-parser.js
@@ -1168,6 +1168,14 @@ function applyReplacements(sql, withAlias, replacements) {
 }
 
 export default function parseFactsFromCustomSQL(factTable, withAlias, sql) {
+  // okay, if our sql has -any- parameters, just bomb out. We don't know how to deal with those yet
+  if (sql.includes("${")) {
+    return {
+      factProjections: [sql],
+      factAliases: [withAlias],
+      expression: sql
+    }
+  }
   const factProjections = []
   const factAliases = []
   let expression = sql


### PR DESCRIPTION
This is a hack that I _think_ will keep us in action but it should be re-visited and done better in the nebulous future.

The problem was correctly diagnosed - the params were preprocessed before hitting the query, so usage couldn't be noted. We needed to hold onto the params until the end for the notation. However, if we did that, then it blew up at an earlier step. 

This is because custom colors are parsing out the query and building an AST and I _swear_ it's doing something with its own templating at this level, but I haven't isolated or proven that.

So this mod here just lets us override some behavior - provide a function to retrieve the color aggregate, and another function to post-process the values that come out of `parseFactsFromCustomSQL`.

Those functions are handed in via immerse and discussed in that PR.

Longer term, `parseFactsFromCustomSQL` and/or `buildAst` could be modified to deal with parameters directly, or we could move notation to another location...but just for the custom color query, which'd suck as a special case.

The immediate ramification is that I _think_ it still works properly, but is likely to break if you have a custom color measure that contains columns from the color table, fact table, and a parameter, since it just blindly re-inserts the original query if a param is found. We can fix that other bug if it's ever reported, possibly by moving notation around and pre-processing, but I really don't want do that.