### PR TITLE
[FE-13942] - table redraw change

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -85418,7 +85418,7 @@ function mapdTable(parent, chartGroup) {
         }
 
         _chart._invokeSortListener(_sortColumn);
-        (0, _coreAsync.redrawAllAsync)(_chart.chartGroup());
+        _chart.redrawAsync();
       });
 
       sortButton.append("svg").attr("class", "svg-icon").classed("icon-sort", true).attr("viewBox", "0 0 48 48").append("use").attr("xlink:href", "#icon-sort");

--- a/src/charts/mapd-table.js
+++ b/src/charts/mapd-table.js
@@ -467,7 +467,7 @@ export default function mapdTable(parent, chartGroup) {
           }
 
           _chart._invokeSortListener(_sortColumn)
-          redrawAllAsync(_chart.chartGroup())
+          _chart.redrawAsync()
         })
 
       sortButton


### PR DESCRIPTION
I dunno if this is really worth incorporating at this point for 5.7. It's a trivial change, but it's table chart, so it's _never_ a trivial change.

Anyway, way back in the olden days of _four years ago_, mapd-table was wired up so that when you click the sort button, it'd fire off a `redrawAllAsync` on the chart's group, which'd cause needless re-querying on other charts.

This changes to just call the single chart's `redrawAsync` in its place. I think it works, but I'll never have confidence in anything table related. 

And it looks like an ancient issue. So maybe it's not worth sticking in in the last minutes of 5.7? I dunno.