### PR TITLE
renames pointmap transform from point -> location

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -56648,7 +56648,7 @@ function rasterLayerPointMixin(_layer) {
       if (isDataExport) {
         transforms.push({
           type: "project",
-          expr: "ST_SetSRID(ST_Point(" + AGGREGATES[x.aggregate] + "(" + x.field + "), " + AGGREGATES[y.aggregate] + "(" + y.field + ")), 4326) as point"
+          expr: "ST_SetSRID(ST_Point(" + AGGREGATES[x.aggregate] + "(" + x.field + "), " + AGGREGATES[y.aggregate] + "(" + y.field + ")), 4326) AS location"
         });
       }
     } else {

--- a/src/mixins/raster-layer-point-mixin.js
+++ b/src/mixins/raster-layer-point-mixin.js
@@ -245,7 +245,7 @@ export default function rasterLayerPointMixin(_layer) {
           type: "project",
           expr: `ST_SetSRID(ST_Point(${AGGREGATES[x.aggregate]}(${x.field}), ${
             AGGREGATES[y.aggregate]
-          }(${y.field})), 4326) as point`
+          }(${y.field})), 4326) AS location`
         })
       }
     } else {


### PR DESCRIPTION
Renames `point` to `transform` in pointmap csv exports to avoid using a [reserved word](https://docs-new.omnisci.com/sql/data-manipulation-dml/omnisci-reserved-words).