### PR TITLE
[FE-14191][FE-14196] Limit pretty-printed aliases to data exports

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -56641,7 +56641,7 @@ function rasterLayerPointMixin(_layer) {
           return {
             type: "project",
             expr: "" + (isDataExport && i === 0 ? "/*+ cpu_mode */ " : "") + g,
-            as: g
+            as: isDataExport ? g : "key" + i
           };
         })
       });

--- a/src/mixins/raster-layer-point-mixin.js
+++ b/src/mixins/raster-layer-point-mixin.js
@@ -237,7 +237,7 @@ export default function rasterLayerPointMixin(_layer) {
         groupby: transform.groupby.map((g, i) => ({
           type: "project",
           expr: `${isDataExport && i === 0 ? "/*+ cpu_mode */ " : ""}${g}`,
-          as: g
+          as: isDataExport ? g : `key${i}`
         }))
       })
       if (isDataExport) {


### PR DESCRIPTION
Only pretty-print aliases when exporting data. Custom SQL dimensions could break the generated query here, and hit-testing also seems to depend on the previous `key[#]` aliases.

(This does _not_ fix exporting data with custom SQL dimensions—wrapping the group by in quotation marks seems to generate valid SQL, but still fails validation somewhere down the line?)

Fixes FE-14191, FE-14196
