### PR TITLE
[FE-14661] Replaces distance_in_meters with st_dwithin for lasso circle filters

### DIFF
--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -56942,7 +56942,7 @@ function rasterLayerPointMixin(_layer) {
     var scales = (0, _utilsVega.getScales)(state.encoding, layerName, scaledomainfields, getStatsLayerName());
 
     var marks = [{
-      type: markType === "airplane" ? "legacysymbol" : "symbol",
+      type: "symbol",
       from: {
         data: layerName
       },

--- a/dist/mapdc.js
+++ b/dist/mapdc.js
@@ -51740,7 +51740,7 @@ function rasterDrawMixin(chart) {
                 // convert from mercator to lat-lon
                 LatLonUtils.conv900913To4326(pos, pos);
                 var meters = shape.radius * 1000;
-                filterObj.shapeFilters.push("DISTANCE_IN_METERS(" + pos[0] + ", " + pos[1] + ", " + px + ", " + py + ") < " + meters);
+                filterObj.shapeFilters.push("ST_DWithin(CAST(ST_SetSRID(ST_Point(" + pos[0] + ", " + pos[1] + "), 4326) as GEOGRAPHY), CAST(ST_SetSRID(ST_Point(" + px + ", " + py + "), 4326) as GEOGRAPHY), " + meters + ")");
               } else if (shape instanceof MapdDraw.Circle) {
                 var radsqr = Math.pow(shape.radius, 2);
                 var mat = MapdDraw.Mat2d.clone(shape.globalXform);

--- a/src/mixins/raster-draw-mixin.js
+++ b/src/mixins/raster-draw-mixin.js
@@ -235,7 +235,7 @@ export function rasterDrawMixin(chart) {
                 LatLonUtils.conv900913To4326(pos, pos)
                 const meters = shape.radius * 1000
                 filterObj.shapeFilters.push(
-                  `DISTANCE_IN_METERS(${pos[0]}, ${pos[1]}, ${px}, ${py}) < ${meters}`
+                  `ST_DWithin(CAST(ST_SetSRID(ST_Point(${pos[0]}, ${pos[1]}), 4326) as GEOGRAPHY), CAST(ST_SetSRID(ST_Point(${px}, ${py}), 4326) as GEOGRAPHY), ${meters})`
                 )
               } else if (shape instanceof MapdDraw.Circle) {
                 const radsqr = Math.pow(shape.radius, 2)

--- a/src/mixins/raster-layer-point-mixin.js
+++ b/src/mixins/raster-layer-point-mixin.js
@@ -581,7 +581,7 @@ export default function rasterLayerPointMixin(_layer) {
 
     const marks = [
       {
-        type: markType === "airplane" ? "legacysymbol" : "symbol",
+        type: "symbol",
         from: {
           data: layerName
         },

--- a/src/utils/utils-lasso.js
+++ b/src/utils/utils-lasso.js
@@ -25,7 +25,7 @@ function convertFeatureToCircleStmt({ geometry: { radius, center } }, px, py) {
   const lat2 = center[1]
   const lon2 = center[0]
   const meters = radius * 1000
-  return `DISTANCE_IN_METERS(${lon2}, ${lat2}, ${px}, ${py}) < ${meters}`
+  return `ST_DWithin(CAST(ST_SetSRID(ST_Point(${lon2}, ${lat2}), 4326) as GEOGRAPHY), CAST(ST_SetSRID(ST_Point(${px}, ${py}), 4326) as GEOGRAPHY), ${meters})`
 }
 
 function convertFeatureToContainsStmt({ geometry }, px, py) {

--- a/src/utils/utils-lasso.unit.spec.js
+++ b/src/utils/utils-lasso.unit.spec.js
@@ -61,7 +61,7 @@ describe("convertGeojsonToSql", () => {
     ]
 
     expect(utils.convertGeojsonToSql(features, "lon", "lat")).to.equal(
-      "((DISTANCE_IN_METERS(0, 0, lon, lat) < 1000000))"
+      "((ST_DWithin(CAST(ST_SetSRID(ST_Point(0, 0), 4326) as GEOGRAPHY), CAST(ST_SetSRID(ST_Point(lon, lat), 4326) as GEOGRAPHY), 1000000)))"
     )
   })
 
@@ -138,7 +138,7 @@ describe("convertGeojsonToSql", () => {
     ]
 
     expect(utils.convertGeojsonToSql(features, "lon", "lat")).to.equal(
-      "(UNLIKELY( lon >= -128.320313 AND lon <= -40.429688 AND lat >= -9.661713 AND lat <= 51.483925)) AND ((ST_Contains('POLYGON ((-84.023438 51.483925, -40.429688 22.069062, -124.453125 -9.661713, -128.320313 29.958472, -84.023438 51.483925))', ST_Point(lon, lat))) OR (DISTANCE_IN_METERS(0, 0, lon, lat) < 1000000))"
+      "(UNLIKELY( lon >= -128.320313 AND lon <= -40.429688 AND lat >= -9.661713 AND lat <= 51.483925)) AND ((ST_Contains('POLYGON ((-84.023438 51.483925, -40.429688 22.069062, -124.453125 -9.661713, -128.320313 29.958472, -84.023438 51.483925))', ST_Point(lon, lat))) OR (ST_DWithin(CAST(ST_SetSRID(ST_Point(0, 0), 4326) as GEOGRAPHY), CAST(ST_SetSRID(ST_Point(lon, lat), 4326) as GEOGRAPHY), 1000000)))"
     )
   })
 


### PR DESCRIPTION
Also changed the airplane symbol mark to be normal "symbol" since I was in here. The airplane was added to our stock symbols for the `symbol` mark some time ago.


# Merge Checklist
## :wrench: Issue(s) fixed:
- [ ] Author referenced issue(s) fixed by this PR:
- [ ] Fixes [FE-14661]

## :smoking: Smoke Test
- [ ] Works in chrome
- [ ] Works in firefox
- [ ] Works in safari
- [ ] Works in ie edge
- [ ] Works in ie 11

## :ship: Merge
- [ ] author crafted PR's title into release-worthy commit message.


[FE-14661]: https://omnisci.atlassian.net/browse/FE-14661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ